### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/168/223/421168223.geojson
+++ b/data/421/168/223/421168223.geojson
@@ -79,6 +79,9 @@
     },
     "wof:country":"JM",
     "wof:created":1459008758,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8981193b4caa266d0cd1ad8e306d8130",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
         }
     ],
     "wof:id":421168223,
-    "wof:lastmodified":1566724660,
+    "wof:lastmodified":1582319503,
     "wof:name":"Old Harbour Bay",
     "wof:parent_id":85672601,
     "wof:placetype":"locality",

--- a/data/421/186/515/421186515.geojson
+++ b/data/421/186/515/421186515.geojson
@@ -537,6 +537,10 @@
     },
     "wof:country":"JM",
     "wof:created":1459009483,
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"64611cb20eb56ce0c125e11c7fe1bca0",
     "wof:hierarchy":[
         {
@@ -547,7 +551,7 @@
         }
     ],
     "wof:id":421186515,
-    "wof:lastmodified":1566724662,
+    "wof:lastmodified":1582319503,
     "wof:name":"Kingston",
     "wof:parent_id":85672609,
     "wof:placetype":"locality",

--- a/data/421/202/975/421202975.geojson
+++ b/data/421/202/975/421202975.geojson
@@ -159,6 +159,9 @@
     },
     "wof:country":"JM",
     "wof:created":1459010136,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"92628d307faa01bdcfaddd2c785e83c6",
     "wof:hierarchy":[
         {
@@ -169,7 +172,7 @@
         }
     ],
     "wof:id":421202975,
-    "wof:lastmodified":1566724662,
+    "wof:lastmodified":1582319503,
     "wof:name":"Port Morant",
     "wof:parent_id":85672615,
     "wof:placetype":"locality",

--- a/data/856/322/15/85632215.geojson
+++ b/data/856/322/15/85632215.geojson
@@ -963,6 +963,12 @@
     },
     "wof:country":"JM",
     "wof:country_alpha3":"JAM",
+    "wof:geom_alt":[
+        "meso",
+        "quattroshapes",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"e8f12b6a2fb5e52be9f1d846e3fa955f",
     "wof:hierarchy":[
         {
@@ -977,7 +983,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566724616,
+    "wof:lastmodified":1582319500,
     "wof:name":"Jamaica",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/725/59/85672559.geojson
+++ b/data/856/725/59/85672559.geojson
@@ -272,6 +272,9 @@
         "wk:page":"Clarendon Parish, Jamaica"
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a79ac9b958fb663d2158ca2eb837cb4b",
     "wof:hierarchy":[
         {
@@ -287,7 +290,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566724614,
+    "wof:lastmodified":1582319498,
     "wof:name":"Clarendon",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/63/85672563.geojson
+++ b/data/856/725/63/85672563.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Hanover Parish"
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e9cc00ab37bf48c87b29202df63c668e",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566724615,
+    "wof:lastmodified":1582319499,
     "wof:name":"Hanover",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/67/85672567.geojson
+++ b/data/856/725/67/85672567.geojson
@@ -268,6 +268,9 @@
         "wk:page":"Manchester Parish"
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"521c1f561ff94765eb0c515fb86da9fd",
     "wof:hierarchy":[
         {
@@ -283,7 +286,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566724614,
+    "wof:lastmodified":1582319499,
     "wof:name":"Manchester",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/69/85672569.geojson
+++ b/data/856/725/69/85672569.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Saint Elizabeth Parish"
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9b5df93618b608962337b2162a2675c3",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566724614,
+    "wof:lastmodified":1582319498,
     "wof:name":"Saint Elizabeth",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/73/85672573.geojson
+++ b/data/856/725/73/85672573.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Saint James Parish, Jamaica"
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c6b895cd13482d2e5a0486f311f9b5aa",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566724614,
+    "wof:lastmodified":1582319499,
     "wof:name":"Saint James",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/79/85672579.geojson
+++ b/data/856/725/79/85672579.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Trelawny Parish"
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab5330913e5555dc00687f27894d1083",
     "wof:hierarchy":[
         {
@@ -295,7 +298,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566724615,
+    "wof:lastmodified":1582319500,
     "wof:name":"Trelawny",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/83/85672583.geojson
+++ b/data/856/725/83/85672583.geojson
@@ -269,6 +269,9 @@
         "wk:page":"Westmoreland Parish"
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fbf10b497be8dce3f8b49067b00c8fdc",
     "wof:hierarchy":[
         {
@@ -284,7 +287,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566724616,
+    "wof:lastmodified":1582319500,
     "wof:name":"Westmoreland",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/87/85672587.geojson
+++ b/data/856/725/87/85672587.geojson
@@ -316,6 +316,9 @@
         "wk:page":"Kingston Parish"
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"64611cb20eb56ce0c125e11c7fe1bca0",
     "wof:hierarchy":[
         {
@@ -331,7 +334,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566724615,
+    "wof:lastmodified":1582319499,
     "wof:name":"Kingston",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/91/85672591.geojson
+++ b/data/856/725/91/85672591.geojson
@@ -259,6 +259,9 @@
         "wk:page":"Portland Parish"
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6ac351cf09cd09f9276429158c018bcc",
     "wof:hierarchy":[
         {
@@ -274,7 +277,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566724615,
+    "wof:lastmodified":1582319499,
     "wof:name":"Portland",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/99/85672599.geojson
+++ b/data/856/725/99/85672599.geojson
@@ -276,6 +276,9 @@
         "wk:page":"Saint Ann Parish"
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"82f9030ade1b947712d4c33a623c7c05",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566724615,
+    "wof:lastmodified":1582319499,
     "wof:name":"Saint Ann",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/726/01/85672601.geojson
+++ b/data/856/726/01/85672601.geojson
@@ -277,6 +277,9 @@
         "wk:page":"Saint Catherine Parish"
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"510205f42883420e6233e89e0a6903c5",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566724616,
+    "wof:lastmodified":1582319501,
     "wof:name":"Saint Catherine",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/726/05/85672605.geojson
+++ b/data/856/726/05/85672605.geojson
@@ -272,6 +272,9 @@
         "wk:page":"Saint Mary Parish, Jamaica"
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7a3a6d83fe687bc42561a5d6f1945024",
     "wof:hierarchy":[
         {
@@ -287,7 +290,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566724616,
+    "wof:lastmodified":1582319500,
     "wof:name":"Saint Mary",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/726/09/85672609.geojson
+++ b/data/856/726/09/85672609.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Saint Andrew Parish, Jamaica"
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"01935785ba280ebcf3ac3b02bbafbc4e",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566724616,
+    "wof:lastmodified":1582319501,
     "wof:name":"Saint Andrew",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/726/15/85672615.geojson
+++ b/data/856/726/15/85672615.geojson
@@ -274,6 +274,9 @@
         "wk:page":"Saint Thomas Parish, Jamaica"
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2546a34f7479ed0886b3f5c10196c14c",
     "wof:hierarchy":[
         {
@@ -289,7 +292,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566724617,
+    "wof:lastmodified":1582319501,
     "wof:name":"Saint Thomas",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/857/938/87/85793887.geojson
+++ b/data/857/938/87/85793887.geojson
@@ -72,6 +72,9 @@
         "qs:id":1165119
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5a645fb110e4c53fb3e115c0db224287",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1534379371,
+    "wof:lastmodified":1582319498,
     "wof:name":"Beverly Hills",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/91/85793891.geojson
+++ b/data/857/938/91/85793891.geojson
@@ -79,6 +79,9 @@
         "gp:id":108522
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"79727ca50572889ccdf97436409dbaca",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566724613,
+    "wof:lastmodified":1582319498,
     "wof:name":"Camperdown",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/93/85793893.geojson
+++ b/data/857/938/93/85793893.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":118782
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cbd1ae5bf47026640bc9a5e1c5caf147",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566724613,
+    "wof:lastmodified":1582319498,
     "wof:name":"Grants Pen",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/938/99/85793899.geojson
+++ b/data/857/938/99/85793899.geojson
@@ -119,6 +119,10 @@
         "wk:page":"Half Way Tree"
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5423b163848a36d346c865b71452d78a",
     "wof:hierarchy":[
         {
@@ -133,7 +137,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566724613,
+    "wof:lastmodified":1582319498,
     "wof:name":"Half Way Tree",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/939/03/85793903.geojson
+++ b/data/857/939/03/85793903.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":296890
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"03c69d58dd3e5994e29e531527cbf490",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566724613,
+    "wof:lastmodified":1582319498,
     "wof:name":"Hope Pastures",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/939/07/85793907.geojson
+++ b/data/857/939/07/85793907.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":1165132
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"0073bed480d04804c48c7412f3190405",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566724614,
+    "wof:lastmodified":1582319498,
     "wof:name":"Jones Town",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/939/11/85793911.geojson
+++ b/data/857/939/11/85793911.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":211089
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"088d7469ab1e9cfdc4ff5e4501b7e8b1",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566724614,
+    "wof:lastmodified":1582319498,
     "wof:name":"Mona Heights",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/939/15/85793915.geojson
+++ b/data/857/939/15/85793915.geojson
@@ -483,6 +483,10 @@
         "wd:id":"Q34692"
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"89c9f3ab84f440cb86ba399ce5a75044",
     "wof:hierarchy":[
         {
@@ -497,7 +501,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566724614,
+    "wof:lastmodified":1582319498,
     "wof:name":"New Kingston",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/939/19/85793919.geojson
+++ b/data/857/939/19/85793919.geojson
@@ -74,6 +74,9 @@
         "gp:id":109568
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9f7bd10f6763e777382229a115144c8e",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566724614,
+    "wof:lastmodified":1582319498,
     "wof:name":"Newport East",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/939/23/85793923.geojson
+++ b/data/857/939/23/85793923.geojson
@@ -113,6 +113,10 @@
         "wd:id":"Q1753236"
     },
     "wof:country":"JM",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fc34834b4274148306653ef72f2356d6",
     "wof:hierarchy":[
         {
@@ -127,7 +131,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566724614,
+    "wof:lastmodified":1582319498,
     "wof:name":"Trench Town",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/435/481/890435481.geojson
+++ b/data/890/435/481/890435481.geojson
@@ -203,6 +203,9 @@
     },
     "wof:country":"JM",
     "wof:created":1469052069,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e75f48c02c026b07bf30f7d02d15bc41",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":890435481,
-    "wof:lastmodified":1566724666,
+    "wof:lastmodified":1582319504,
     "wof:name":"Port Antonio",
     "wof:parent_id":85672591,
     "wof:placetype":"locality",

--- a/data/890/439/969/890439969.geojson
+++ b/data/890/439/969/890439969.geojson
@@ -281,6 +281,9 @@
     },
     "wof:country":"JM",
     "wof:created":1469052257,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c51b820ca0f11cc6647df512db752c2d",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
         }
     ],
     "wof:id":890439969,
-    "wof:lastmodified":1566724665,
+    "wof:lastmodified":1582319503,
     "wof:name":"Spanish Town",
     "wof:parent_id":85672601,
     "wof:placetype":"locality",

--- a/data/890/444/671/890444671.geojson
+++ b/data/890/444/671/890444671.geojson
@@ -311,6 +311,9 @@
     },
     "wof:country":"JM",
     "wof:created":1469052477,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1de0e6b1aed226ba20411f3ffbc6f7ed",
     "wof:hierarchy":[
         {
@@ -321,7 +324,7 @@
         }
     ],
     "wof:id":890444671,
-    "wof:lastmodified":1566724665,
+    "wof:lastmodified":1582319503,
     "wof:name":"Montego Bay",
     "wof:parent_id":85672573,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.