### PR TITLE
Name updates

### DIFF
--- a/data/856/322/15/85632215.geojson
+++ b/data/856/322/15/85632215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.938017,
-    "geom:area_square_m":11021084737.540695,
+    "geom:area_square_m":11021084736.596115,
     "geom:bbox":"-78.368174,17.70548,-76.182652,18.525489",
     "geom:latitude":18.158395,
     "geom:longitude":-77.310567,
@@ -52,6 +52,9 @@
     ],
     "name:arg_x_preferred":[
         "Chamaica"
+    ],
+    "name:ary_x_preferred":[
+        "\u062c\u0627\u0645\u0627\u064a\u0643\u0627"
     ],
     "name:arz_x_preferred":[
         "\u0686\u0627\u0645\u0627\u064a\u0643\u0627"
@@ -144,6 +147,9 @@
     "name:cor_x_preferred":[
         "Jamayka"
     ],
+    "name:cos_x_preferred":[
+        "Giamaica"
+    ],
     "name:crh_x_preferred":[
         "Camayka"
     ],
@@ -152,6 +158,12 @@
     ],
     "name:dan_x_preferred":[
         "Jamaica"
+    ],
+    "name:deu_at_x_preferred":[
+        "Jamaika"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Jamaika"
     ],
     "name:deu_x_preferred":[
         "Jamaika"
@@ -179,6 +191,12 @@
     ],
     "name:ell_x_preferred":[
         "\u03a4\u03b6\u03b1\u03bc\u03ac\u03b9\u03ba\u03b1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Jamaica"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Jamaica"
     ],
     "name:eng_x_preferred":[
         "Jamaica"
@@ -246,6 +264,9 @@
     ],
     "name:gag_x_preferred":[
         "Yamayka"
+    ],
+    "name:gcr_x_preferred":[
+        "Janmayk"
     ],
     "name:gla_x_preferred":[
         "Iaimeuca"
@@ -322,6 +343,9 @@
     ],
     "name:hye_x_variant":[
         "\u054b\u0561\u0574\u0561\u0575\u056f\u0561"
+    ],
+    "name:hyw_x_preferred":[
+        "\u053a\u0561\u0574\u0561\u0575\u0584\u0561"
     ],
     "name:ibo_x_preferred":[
         "Jamaik\u1ea1"
@@ -486,6 +510,9 @@
     "name:mon_x_preferred":[
         "\u042f\u043c\u0430\u0439\u043a"
     ],
+    "name:mri_x_preferred":[
+        "Hemeika"
+    ],
     "name:mrj_x_preferred":[
         "\u042f\u043c\u0430\u0439\u043a\u0430"
     ],
@@ -603,6 +630,9 @@
     "name:pol_x_preferred":[
         "Jamajka"
     ],
+    "name:por_br_x_preferred":[
+        "Jamaica"
+    ],
     "name:por_x_preferred":[
         "Jamaica"
     ],
@@ -638,6 +668,9 @@
     ],
     "name:san_x_preferred":[
         "\u091c\u092e\u0948\u0915\u093e"
+    ],
+    "name:sat_x_preferred":[
+        "\u1c61\u1c5f\u1c62\u1c5f\u1c6d\u1c60\u1c5f"
     ],
     "name:scn_x_preferred":[
         "Giamaica"
@@ -690,6 +723,12 @@
     "name:srn_x_preferred":[
         "Jamaica"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u0408\u0430\u043c\u0430\u0458\u043a\u0430"
+    ],
+    "name:srp_el_x_preferred":[
+        "Jamajka"
+    ],
     "name:srp_x_preferred":[
         "\u0408\u0430\u043c\u0430\u0458\u043a\u0430"
     ],
@@ -707,6 +746,9 @@
     ],
     "name:szl_x_preferred":[
         "Jamajka"
+    ],
+    "name:szy_x_preferred":[
+        "Jamaica"
     ],
     "name:tam_x_preferred":[
         "\u0b9c\u0bae\u0bc7\u0b95\u0bcd\u0b95\u0bbe"
@@ -750,6 +792,9 @@
     ],
     "name:tur_x_preferred":[
         "Jamaika"
+    ],
+    "name:udm_x_preferred":[
+        "\u042f\u043c\u0430\u0439\u043a\u0430"
     ],
     "name:uig_x_preferred":[
         "\u064a\u0627\u0645\u0627\u064a\u0643\u0627"
@@ -817,8 +862,26 @@
     "name:zha_x_preferred":[
         "Jamaica"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u7259\u4e70\u52a0"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u7259\u8cb7\u52a0"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Jamaica"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u7259\u8cb7\u52a0"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u7259\u4e70\u52a0"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u7259\u4e70\u52a0"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u7259\u8cb7\u52a0"
     ],
     "name:zho_x_preferred":[
         "\u7259\u4e70\u52a0"
@@ -984,7 +1047,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1583797368,
+    "wof:lastmodified":1587427960,
     "wof:name":"Jamaica",
     "wof:parent_id":102191575,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.