### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/586/840/7/1125868407.geojson
+++ b/data/112/586/840/7/1125868407.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Yallahs"
+    ],
     "name:bul_x_preferred":[
         "\u042f\u043b\u0430\u0445\u0441"
     ],
@@ -38,6 +41,9 @@
         "Yallahs"
     ],
     "name:nld_x_preferred":[
+        "Yallahs"
+    ],
+    "name:pol_x_preferred":[
         "Yallahs"
     ],
     "name:swe_x_preferred":[
@@ -89,7 +95,7 @@
         }
     ],
     "wof:id":1125868407,
-    "wof:lastmodified":1566724666,
+    "wof:lastmodified":1690937479,
     "wof:name":"Yallahs",
     "wof:parent_id":85672615,
     "wof:placetype":"locality",

--- a/data/112/586/841/5/1125868415.geojson
+++ b/data/112/586/841/5/1125868415.geojson
@@ -22,6 +22,12 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:cat_x_preferred":[
+        "Williamsfield"
+    ],
+    "name:ceb_x_preferred":[
+        "Williamsfield"
+    ],
     "name:eng_x_preferred":[
         "Williamsfield"
     ],
@@ -30,6 +36,12 @@
     ],
     "name:nld_x_preferred":[
         "Williamsfield"
+    ],
+    "name:swe_x_preferred":[
+        "Williamsfield"
+    ],
+    "name:urd_x_preferred":[
+        "\u0648\u0644\u06cc\u0645\u0632\u0641\u06cc\u0644\u0688"
     ],
     "qs_pg:aaroncc":"JM",
     "qs_pg:gn_country":"JM",
@@ -68,7 +80,7 @@
         }
     ],
     "wof:id":1125868415,
-    "wof:lastmodified":1566724666,
+    "wof:lastmodified":1690937479,
     "wof:name":"Williamsfield",
     "wof:parent_id":85672567,
     "wof:placetype":"locality",

--- a/data/112/586/842/5/1125868425.geojson
+++ b/data/112/586/842/5/1125868425.geojson
@@ -25,6 +25,12 @@
     "name:ben_x_preferred":[
         "\u0993\u09af\u09bc\u09c7\u0995\u09ab\u09bf\u09b2\u09cd\u09a1"
     ],
+    "name:ceb_x_preferred":[
+        "Wakefield"
+    ],
+    "name:deu_x_preferred":[
+        "Wakefield"
+    ],
     "name:ell_x_preferred":[
         "\u0393\u03bf\u03c5\u03ad\u03b9\u03ba\u03c6\u03b9\u03bb\u03bd\u03c4"
     ],
@@ -38,6 +44,9 @@
         "Wakefield"
     ],
     "name:nld_x_preferred":[
+        "Wakefield"
+    ],
+    "name:swe_x_preferred":[
         "Wakefield"
     ],
     "name:vie_x_preferred":[
@@ -80,7 +89,7 @@
         }
     ],
     "wof:id":1125868425,
-    "wof:lastmodified":1636495996,
+    "wof:lastmodified":1690937479,
     "wof:name":"Wakefield",
     "wof:parent_id":85672579,
     "wof:placetype":"locality",

--- a/data/112/586/843/9/1125868439.geojson
+++ b/data/112/586/843/9/1125868439.geojson
@@ -22,10 +22,16 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ceb_x_preferred":[
+        "Southfield"
+    ],
     "name:eng_x_preferred":[
         "Southfield"
     ],
     "name:nld_x_preferred":[
+        "Southfield"
+    ],
+    "name:swe_x_preferred":[
         "Southfield"
     ],
     "name:urd_x_preferred":[
@@ -71,7 +77,7 @@
         }
     ],
     "wof:id":1125868439,
-    "wof:lastmodified":1566724666,
+    "wof:lastmodified":1690937479,
     "wof:name":"Southfield",
     "wof:parent_id":85672569,
     "wof:placetype":"locality",

--- a/data/112/588/020/7/1125880207.geojson
+++ b/data/112/588/020/7/1125880207.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Runaway Bay"
+    ],
     "name:ceb_x_preferred":[
         "Runaway Bay"
     ],
@@ -38,6 +41,9 @@
         "Runaway Bay"
     ],
     "name:nld_x_preferred":[
+        "Runaway Bay"
+    ],
+    "name:pol_x_preferred":[
         "Runaway Bay"
     ],
     "name:srp_x_preferred":[
@@ -89,7 +95,7 @@
         }
     ],
     "wof:id":1125880207,
-    "wof:lastmodified":1566724666,
+    "wof:lastmodified":1690937480,
     "wof:name":"Runaway Bay",
     "wof:parent_id":85672599,
     "wof:placetype":"locality",

--- a/data/112/589/481/3/1125894813.geojson
+++ b/data/112/589/481/3/1125894813.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Porus"
+    ],
     "name:bul_x_preferred":[
         "\u041f\u043e\u0440\u0443\u0441"
     ],
@@ -38,6 +41,9 @@
         "Porus"
     ],
     "name:nld_x_preferred":[
+        "Porus"
+    ],
+    "name:pol_x_preferred":[
         "Porus"
     ],
     "name:swe_x_preferred":[
@@ -83,7 +89,7 @@
         }
     ],
     "wof:id":1125894813,
-    "wof:lastmodified":1566724666,
+    "wof:lastmodified":1690937481,
     "wof:name":"Porus",
     "wof:parent_id":85672567,
     "wof:placetype":"locality",

--- a/data/112/589/489/1/1125894891.geojson
+++ b/data/112/589/489/1/1125894891.geojson
@@ -25,8 +25,14 @@
     "name:ara_x_preferred":[
         "\u0623\u0648\u062a\u0634\u0648 \u0631\u064a\u0648\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u062a\u0634\u0648 \u0631\u064a\u0648\u0633"
+    ],
     "name:bel_x_preferred":[
         "\u041e\u0447\u0430-\u0420\u044b\u044f\u0441"
+    ],
+    "name:cat_x_preferred":[
+        "Ocho Rios"
     ],
     "name:ceb_x_preferred":[
         "Ocho Rios"
@@ -131,7 +137,7 @@
         }
     ],
     "wof:id":1125894891,
-    "wof:lastmodified":1566724667,
+    "wof:lastmodified":1690937481,
     "wof:name":"Ocho Rios",
     "wof:parent_id":85672599,
     "wof:placetype":"locality",

--- a/data/112/589/490/3/1125894903.geojson
+++ b/data/112/589/490/3/1125894903.geojson
@@ -22,11 +22,17 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Negril"
+    ],
     "name:aze_x_preferred":[
         "Neqril"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041d\u0435\u0433\u0440\u044b\u043b"
+    ],
+    "name:bel_x_variant":[
+        "\u041d\u0435\u0433\u0440\u044b\u043b"
     ],
     "name:bul_x_preferred":[
         "\u041d\u0435\u0433\u0440\u0438\u043b"
@@ -37,8 +43,14 @@
     "name:deu_x_preferred":[
         "Negril"
     ],
+    "name:ell_x_preferred":[
+        "\u039d\u03b5\u03b3\u03ba\u03c1\u03af\u03bb"
+    ],
     "name:eng_x_preferred":[
         "Negril"
+    ],
+    "name:fas_x_preferred":[
+        "\u0646\u06af\u0631\u06cc\u0644"
     ],
     "name:fra_x_preferred":[
         "Negril"
@@ -61,6 +73,9 @@
     "name:pol_x_preferred":[
         "Negril"
     ],
+    "name:por_x_preferred":[
+        "Negril"
+    ],
     "name:rus_x_preferred":[
         "\u041d\u0435\u0433\u0440\u0438\u043b"
     ],
@@ -69,6 +84,9 @@
     ],
     "name:und_x_variant":[
         "Negril Harbour"
+    ],
+    "name:urd_x_preferred":[
+        "\u0646\u06cc\u06af\u0631\u0644"
     ],
     "name:zho_x_preferred":[
         "\u5167\u683c\u91cc\u723e"
@@ -110,7 +128,7 @@
         }
     ],
     "wof:id":1125894903,
-    "wof:lastmodified":1566724666,
+    "wof:lastmodified":1690937480,
     "wof:name":"Negril",
     "wof:parent_id":85672583,
     "wof:placetype":"locality",

--- a/data/112/589/490/9/1125894909.geojson
+++ b/data/112/589/490/9/1125894909.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Nain"
+    ],
     "name:eng_x_preferred":[
         "Nain"
     ],
@@ -80,7 +83,7 @@
         }
     ],
     "wof:id":1125894909,
-    "wof:lastmodified":1636495996,
+    "wof:lastmodified":1690937480,
     "wof:name":"Nain",
     "wof:parent_id":85672569,
     "wof:placetype":"locality",

--- a/data/112/589/491/9/1125894919.geojson
+++ b/data/112/589/491/9/1125894919.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Chapelton"
+    ],
     "name:ceb_x_preferred":[
         "Chapelton"
     ],
@@ -34,8 +37,17 @@
     "name:heb_x_preferred":[
         "\u05e6'\u05d0\u05e4\u05dc\u05d8\u05d5\u05df"
     ],
+    "name:lit_x_preferred":[
+        "\u010capeltonas"
+    ],
     "name:nld_x_preferred":[
         "Chapelton"
+    ],
+    "name:pol_x_preferred":[
+        "Chapelton"
+    ],
+    "name:rus_x_preferred":[
+        "\u0427\u0430\u043f\u0435\u043b\u0442\u043e\u043d"
     ],
     "name:spa_x_preferred":[
         "Chapelton"
@@ -86,7 +98,7 @@
         }
     ],
     "wof:id":1125894919,
-    "wof:lastmodified":1566724666,
+    "wof:lastmodified":1690937481,
     "wof:name":"Chapelton",
     "wof:parent_id":85672559,
     "wof:placetype":"locality",

--- a/data/112/593/815/7/1125938157.geojson
+++ b/data/112/593/815/7/1125938157.geojson
@@ -28,6 +28,12 @@
     "name:ara_x_variant":[
         "\u0644\u0648\u0633\u064a\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u0648\u0633\u064a\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Lucea"
+    ],
     "name:bel_x_preferred":[
         "\u041b\u0443\u0441\u0435\u0430"
     ],
@@ -38,6 +44,9 @@
         "Lucea"
     ],
     "name:ceb_x_preferred":[
+        "Lucea"
+    ],
+    "name:dan_x_preferred":[
         "Lucea"
     ],
     "name:deu_x_preferred":[
@@ -88,6 +97,12 @@
     "name:nld_x_preferred":[
         "Lucea"
     ],
+    "name:nno_x_preferred":[
+        "Lucea"
+    ],
+    "name:nob_x_preferred":[
+        "Lucea"
+    ],
     "name:pol_x_preferred":[
         "Lucea"
     ],
@@ -103,8 +118,14 @@
     "name:swe_x_preferred":[
         "Lucea"
     ],
+    "name:szl_x_preferred":[
+        "Lucea"
+    ],
     "name:tur_x_preferred":[
         "Lucea"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041b\u0443\u0441\u0435\u0430"
     ],
     "name:urd_x_preferred":[
         "\u0644\u0648\u0633\u06cc\u0627"
@@ -152,7 +173,7 @@
         }
     ],
     "wof:id":1125938157,
-    "wof:lastmodified":1636495996,
+    "wof:lastmodified":1690937478,
     "wof:name":"Lucea",
     "wof:parent_id":85672563,
     "wof:placetype":"locality",

--- a/data/112/593/817/9/1125938179.geojson
+++ b/data/112/593/817/9/1125938179.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_preferred":[
         "\u0641\u0627\u0644\u0645\u0648\u062b"
     ],
+    "name:ara_x_variant":[
+        "\u0641\u0627\u0644\u0645\u0627\u0648\u062b"
+    ],
+    "name:ast_x_preferred":[
+        "Falmouth"
+    ],
     "name:bel_x_preferred":[
         "\u0424\u0430\u043b\u043c\u0443\u0442"
     ],
@@ -57,6 +63,9 @@
     ],
     "name:heb_x_preferred":[
         "\u05e4\u05d0\u05dc\u05de\u05d5\u05ea'"
+    ],
+    "name:hin_x_preferred":[
+        "\u092b\u093e\u0932\u092e\u093e\u0909\u0925"
     ],
     "name:hun_x_preferred":[
         "Falmouth"
@@ -102,6 +111,9 @@
     ],
     "name:tur_x_preferred":[
         "Falmouth"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0424\u0430\u043b\u043c\u0443\u0442"
     ],
     "name:urd_x_preferred":[
         "\u0641\u0644\u0627\u0645\u0627\u0648\u0679\u06be\u060c \u062c\u0645\u06cc\u06a9\u0627"
@@ -152,7 +164,7 @@
         }
     ],
     "wof:id":1125938179,
-    "wof:lastmodified":1636495996,
+    "wof:lastmodified":1690937478,
     "wof:name":"Falmouth",
     "wof:parent_id":85672579,
     "wof:placetype":"locality",

--- a/data/112/593/818/9/1125938189.geojson
+++ b/data/112/593/818/9/1125938189.geojson
@@ -22,6 +22,15 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Morant Bay"
+    ],
+    "name:bel_x_preferred":[
+        "\u041c\u043e\u0440\u0430\u043d\u0442-\u0411\u0435\u0439"
+    ],
+    "name:cat_x_preferred":[
+        "Morant Bay"
+    ],
     "name:ceb_x_preferred":[
         "Morant Bay"
     ],
@@ -30,6 +39,9 @@
     ],
     "name:ell_x_preferred":[
         "\u039c\u03cc\u03c1\u03b1\u03bd\u03c4 \u039c\u03c0\u03ad\u03c5"
+    ],
+    "name:ell_x_variant":[
+        "\u039c\u03cc\u03c1\u03b1\u03bd\u03c4 \u039c\u03c0\u03ad\u03b9"
     ],
     "name:eng_x_preferred":[
         "Morant Bay"
@@ -63,6 +75,9 @@
     ],
     "name:swe_x_preferred":[
         "Morant Bay"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041c\u043e\u0440\u0430\u043d\u0442-\u0411\u0435\u0439"
     ],
     "name:und_x_variant":[
         "Morant"
@@ -110,7 +125,7 @@
         }
     ],
     "wof:id":1125938189,
-    "wof:lastmodified":1566724666,
+    "wof:lastmodified":1690937477,
     "wof:name":"Morant Bay",
     "wof:parent_id":85672615,
     "wof:placetype":"locality",

--- a/data/112/593/821/7/1125938217.geojson
+++ b/data/112/593/821/7/1125938217.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Lionel Town"
+    ],
     "name:ceb_x_preferred":[
         "Lionel Town"
     ],
@@ -38,6 +41,9 @@
         "\u05dc\u05d9\u05d0\u05d5\u05e0\u05dc \u05d8\u05d0\u05d5\u05df"
     ],
     "name:nld_x_preferred":[
+        "Lionel Town"
+    ],
+    "name:pol_x_preferred":[
         "Lionel Town"
     ],
     "name:swe_x_preferred":[
@@ -83,7 +89,7 @@
         }
     ],
     "wof:id":1125938217,
-    "wof:lastmodified":1566724666,
+    "wof:lastmodified":1690937478,
     "wof:name":"Lionel Town",
     "wof:parent_id":85672559,
     "wof:placetype":"locality",

--- a/data/112/593/823/1/1125938231.geojson
+++ b/data/112/593/823/1/1125938231.geojson
@@ -22,10 +22,16 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Anchovy"
+    ],
     "name:bul_x_preferred":[
         "\u0410\u043d\u0447\u043e\u0432\u0439"
     ],
     "name:ceb_x_preferred":[
+        "Anchovy"
+    ],
+    "name:deu_x_preferred":[
         "Anchovy"
     ],
     "name:eng_x_preferred":[
@@ -92,7 +98,7 @@
         }
     ],
     "wof:id":1125938231,
-    "wof:lastmodified":1566724666,
+    "wof:lastmodified":1690937478,
     "wof:name":"Anchovy",
     "wof:parent_id":85672573,
     "wof:placetype":"locality",

--- a/data/112/593/825/7/1125938257.geojson
+++ b/data/112/593/825/7/1125938257.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ceb_x_preferred":[
+        "Alexandria"
+    ],
     "name:eng_x_preferred":[
         "Alexandria"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:spa_x_preferred":[
         "Lucea"
+    ],
+    "name:swe_x_preferred":[
+        "Alexandria"
     ],
     "qs_pg:aaroncc":"JM",
     "qs_pg:gn_country":"JM",
@@ -77,7 +83,7 @@
         }
     ],
     "wof:id":1125938257,
-    "wof:lastmodified":1566724666,
+    "wof:lastmodified":1690937479,
     "wof:name":"Alexandria",
     "wof:parent_id":85672599,
     "wof:placetype":"locality",

--- a/data/112/596/240/1/1125962401.geojson
+++ b/data/112/596/240/1/1125962401.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ceb_x_preferred":[
+        "Bull Savanna"
+    ],
     "name:deu_x_preferred":[
         "Bull Savanna"
     ],
@@ -29,6 +32,9 @@
         "Bull Savanna"
     ],
     "name:nld_x_preferred":[
+        "Bull Savanna"
+    ],
+    "name:swe_x_preferred":[
         "Bull Savanna"
     ],
     "qs_pg:aaroncc":"JM",
@@ -68,7 +74,7 @@
         }
     ],
     "wof:id":1125962401,
-    "wof:lastmodified":1566724667,
+    "wof:lastmodified":1690937481,
     "wof:name":"Bull Savanna",
     "wof:parent_id":85672569,
     "wof:placetype":"locality",

--- a/data/114/190/608/9/1141906089.geojson
+++ b/data/114/190/608/9/1141906089.geojson
@@ -24,6 +24,12 @@
     "name:ara_x_variant":[
         "\u0644\u0648\u0633\u064a\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u0648\u0633\u064a\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Lucea"
+    ],
     "name:bel_x_preferred":[
         "\u041b\u0443\u0441\u0435\u0430"
     ],
@@ -34,6 +40,9 @@
         "Lucea"
     ],
     "name:ceb_x_preferred":[
+        "Lucea"
+    ],
+    "name:dan_x_preferred":[
         "Lucea"
     ],
     "name:deu_x_preferred":[
@@ -84,6 +93,12 @@
     "name:nld_x_preferred":[
         "Lucea"
     ],
+    "name:nno_x_preferred":[
+        "Lucea"
+    ],
+    "name:nob_x_preferred":[
+        "Lucea"
+    ],
     "name:pol_x_preferred":[
         "Lucea"
     ],
@@ -99,8 +114,14 @@
     "name:swe_x_preferred":[
         "Lucea"
     ],
+    "name:szl_x_preferred":[
+        "Lucea"
+    ],
     "name:tur_x_preferred":[
         "Lucea"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041b\u0443\u0441\u0435\u0430"
     ],
     "name:urd_x_preferred":[
         "\u0644\u0648\u0633\u06cc\u0627"
@@ -228,7 +249,7 @@
         }
     ],
     "wof:id":1141906089,
-    "wof:lastmodified":1636496002,
+    "wof:lastmodified":1690937482,
     "wof:name":"Lucea",
     "wof:parent_id":85672563,
     "wof:placetype":"locality",

--- a/data/114/190/609/3/1141906093.geojson
+++ b/data/114/190/609/3/1141906093.geojson
@@ -21,6 +21,12 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0641\u0627\u0646\u0627 \u0644\u0627 \u0645\u0627\u0631"
     ],
+    "name:ara_x_variant":[
+        "\u0633\u0641\u0627\u0646\u0627 \u0644\u0627\u0645\u0627\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "Savanna-la-Mar"
+    ],
     "name:bel_x_preferred":[
         "\u0421\u0430\u0432\u0430\u043d\u0430-\u043b\u0430-\u041c\u0430\u0440"
     ],
@@ -89,6 +95,9 @@
     ],
     "name:tur_x_preferred":[
         "Savanna-la-Mar"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0421\u0430\u0432\u0430\u043d\u043d\u0430-\u043b\u0430-\u041c\u0430\u0440"
     ],
     "name:urd_x_preferred":[
         "\u0633\u0648\u0627\u0646\u0627 \u0644\u0627\u0645\u0627\u0631"
@@ -216,7 +225,7 @@
         }
     ],
     "wof:id":1141906093,
-    "wof:lastmodified":1636496002,
+    "wof:lastmodified":1690937482,
     "wof:name":"Savanna-la-Mar",
     "wof:parent_id":85672583,
     "wof:placetype":"locality",

--- a/data/114/190/609/9/1141906099.geojson
+++ b/data/114/190/609/9/1141906099.geojson
@@ -87,6 +87,9 @@
     "name:tur_x_preferred":[
         "Half Way Tree"
     ],
+    "name:ukr_x_preferred":[
+        "\u0425\u0430\u0444-\u0412\u0435\u0439-\u0422\u0440\u0438"
+    ],
     "name:urd_x_preferred":[
         "\u06c1\u0627\u0641 \u0648\u06d2 \u0679\u0631\u06cc"
     ],
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":1141906099,
-    "wof:lastmodified":1636496002,
+    "wof:lastmodified":1690937482,
     "wof:name":"Half Way Tree",
     "wof:parent_id":85672609,
     "wof:placetype":"locality",

--- a/data/114/190/652/3/1141906523.geojson
+++ b/data/114/190/652/3/1141906523.geojson
@@ -27,6 +27,12 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u064a \u0628\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0649 \u0628\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "May Pen"
+    ],
     "name:bel_x_preferred":[
         "\u041c\u0435\u0439-\u041f\u0435\u043d"
     ],
@@ -81,6 +87,9 @@
     "name:kor_x_preferred":[
         "\uba54\uc774\ud39c"
     ],
+    "name:lit_x_preferred":[
+        "Mei Penas"
+    ],
     "name:nds_x_preferred":[
         "May Pen"
     ],
@@ -93,6 +102,9 @@
     "name:por_x_preferred":[
         "May Pen"
     ],
+    "name:rus_x_preferred":[
+        "\u041c\u0435\u0439-\u041f\u0435\u043d"
+    ],
     "name:spa_x_preferred":[
         "May Pen"
     ],
@@ -101,6 +113,9 @@
     ],
     "name:tur_x_preferred":[
         "May Pen"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041c\u0435\u0439-\u041f\u0435\u043d"
     ],
     "name:urd_x_preferred":[
         "\u0645\u0626\u06d2 \u067e\u06cc\u0646"
@@ -242,7 +257,7 @@
         }
     ],
     "wof:id":1141906523,
-    "wof:lastmodified":1636496001,
+    "wof:lastmodified":1690937482,
     "wof:name":"May Pen",
     "wof:parent_id":85672559,
     "wof:placetype":"locality",

--- a/data/421/167/751/421167751.geojson
+++ b/data/421/167/751/421167751.geojson
@@ -20,6 +20,9 @@
     "name:ceb_x_preferred":[
         "Cascade"
     ],
+    "name:deu_x_preferred":[
+        "Cascade"
+    ],
     "name:eng_x_preferred":[
         "Cascade"
     ],
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":421167751,
-    "wof:lastmodified":1636495993,
+    "wof:lastmodified":1690937464,
     "wof:name":"Cascade",
     "wof:parent_id":85672563,
     "wof:placetype":"locality",

--- a/data/421/168/223/421168223.geojson
+++ b/data/421/168/223/421168223.geojson
@@ -32,6 +32,12 @@
     "name:nld_x_preferred":[
         "Old Harbour Bay"
     ],
+    "name:pol_x_preferred":[
+        "Old Harbour Bay"
+    ],
+    "name:rus_x_preferred":[
+        "\u041e\u043b\u0434-\u0425\u0430\u0440\u0431\u043e\u0440-\u0411\u0435\u0439"
+    ],
     "name:swe_x_preferred":[
         "Old Harbour Bay"
     ],
@@ -92,7 +98,7 @@
         }
     ],
     "wof:id":421168223,
-    "wof:lastmodified":1582319503,
+    "wof:lastmodified":1690937462,
     "wof:name":"Old Harbour Bay",
     "wof:parent_id":85672601,
     "wof:placetype":"locality",

--- a/data/421/168/225/421168225.geojson
+++ b/data/421/168/225/421168225.geojson
@@ -35,6 +35,9 @@
     "name:nld_x_preferred":[
         "Duncans"
     ],
+    "name:pol_x_preferred":[
+        "Duncans"
+    ],
     "name:swe_x_preferred":[
         "Duncans"
     ],
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421168225,
-    "wof:lastmodified":1566724660,
+    "wof:lastmodified":1690937462,
     "wof:name":"Duncons",
     "wof:parent_id":85672579,
     "wof:placetype":"locality",

--- a/data/421/169/071/421169071.geojson
+++ b/data/421/169/071/421169071.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_variant":[
         "\u0627\u0644\u0646\u0647\u0631 \u0627\u0644\u0623\u0633\u0648\u062f"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0646\u0647\u0631 \u0627\u0644\u0627\u0633\u0648\u062f"
+    ],
+    "name:ast_x_preferred":[
+        "Black River"
+    ],
     "name:bel_x_preferred":[
         "\u0411\u043b\u044d\u043a-\u0420\u044b\u0432\u0435\u0440"
     ],
@@ -100,6 +106,9 @@
     ],
     "name:tur_x_preferred":[
         "Black River"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0411\u043b\u0435\u043a-\u0420\u0438\u0432\u0435\u0440"
     ],
     "name:urd_x_preferred":[
         "\u0628\u0644\u06cc\u06a9 \u0631\u06cc\u0648\u0631\u060c \u062c\u0645\u06cc\u06a9\u0627"
@@ -253,7 +262,7 @@
         }
     ],
     "wof:id":421169071,
-    "wof:lastmodified":1636495993,
+    "wof:lastmodified":1690937464,
     "wof:name":"Black River",
     "wof:parent_id":85672569,
     "wof:placetype":"locality",

--- a/data/421/174/761/421174761.geojson
+++ b/data/421/174/761/421174761.geojson
@@ -20,8 +20,17 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0646\u062f\u0641\u064a\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0646\u062f\u0641\u064a\u0644"
+    ],
+    "name:ast_x_preferred":[
+        "Mandeville"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09cd\u09af\u09be\u09a8\u09cd\u09a1\u09c7\u09ad\u09bf\u09b2\u09be"
+    ],
+    "name:cat_x_preferred":[
+        "Mandeville"
     ],
     "name:ceb_x_preferred":[
         "Mandeville"
@@ -74,6 +83,9 @@
     "name:nld_x_preferred":[
         "Mandeville"
     ],
+    "name:nob_x_preferred":[
+        "Mandeville"
+    ],
     "name:pol_x_preferred":[
         "Mandeville"
     ],
@@ -94,6 +106,9 @@
     ],
     "name:tur_x_preferred":[
         "Mandeville"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041c\u0435\u043d\u0434\u0432\u0456\u043b"
     ],
     "name:urd_x_preferred":[
         "\u0645\u0627\u0646\u0688\u06cc\u0648\u06cc\u0644\u06d2"
@@ -244,7 +259,7 @@
         }
     ],
     "wof:id":421174761,
-    "wof:lastmodified":1636495993,
+    "wof:lastmodified":1690937465,
     "wof:name":"Mandeville",
     "wof:parent_id":85672567,
     "wof:placetype":"locality",

--- a/data/421/176/183/421176183.geojson
+++ b/data/421/176/183/421176183.geojson
@@ -17,6 +17,15 @@
     "mz:is_current":1,
     "mz:min_zoom":9.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0644\u064a\u0646\u0633\u062a\u064a\u062f"
+    ],
+    "name:arz_x_preferred":[
+        "\u0644\u064a\u0646\u0633\u062a\u064a\u062f"
+    ],
+    "name:ast_x_preferred":[
+        "Linstead"
+    ],
     "name:bul_x_preferred":[
         "\u041b\u0438\u043d\u0441\u0442\u0435\u0430\u0434"
     ],
@@ -54,6 +63,9 @@
         "Linstead"
     ],
     "name:swe_x_preferred":[
+        "Linstead"
+    ],
+    "name:szl_x_preferred":[
         "Linstead"
     ],
     "name:zho_x_preferred":[
@@ -107,7 +119,7 @@
         }
     ],
     "wof:id":421176183,
-    "wof:lastmodified":1566724665,
+    "wof:lastmodified":1690937472,
     "wof:name":"Linstead",
     "wof:parent_id":85672601,
     "wof:placetype":"locality",

--- a/data/421/176/185/421176185.geojson
+++ b/data/421/176/185/421176185.geojson
@@ -17,10 +17,16 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ceb_x_preferred":[
+        "Golden Grove"
+    ],
     "name:eng_x_preferred":[
         "Golden Grove"
     ],
     "name:nld_x_preferred":[
+        "Golden Grove"
+    ],
+    "name:swe_x_preferred":[
         "Golden Grove"
     ],
     "qs:gn_country":"JM",
@@ -68,7 +74,7 @@
         }
     ],
     "wof:id":421176185,
-    "wof:lastmodified":1566724665,
+    "wof:lastmodified":1690937473,
     "wof:name":"Golden Grove",
     "wof:parent_id":85672615,
     "wof:placetype":"locality",

--- a/data/421/176/187/421176187.geojson
+++ b/data/421/176/187/421176187.geojson
@@ -17,7 +17,13 @@
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0627\u062b(\u062c\u0627\u0645\u0627\u064a\u0643\u0627)"
+    ],
     "name:ceb_x_preferred":[
+        "Bath"
+    ],
+    "name:deu_x_preferred":[
         "Bath"
     ],
     "name:eng_x_preferred":[
@@ -33,6 +39,9 @@
         "\u30d0\u30fc\u30b9"
     ],
     "name:nld_x_preferred":[
+        "Bath"
+    ],
+    "name:pol_x_preferred":[
         "Bath"
     ],
     "name:swe_x_preferred":[
@@ -87,7 +96,7 @@
         }
     ],
     "wof:id":421176187,
-    "wof:lastmodified":1566724665,
+    "wof:lastmodified":1690937472,
     "wof:name":"Bath",
     "wof:parent_id":85672615,
     "wof:placetype":"locality",

--- a/data/421/176/189/421176189.geojson
+++ b/data/421/176/189/421176189.geojson
@@ -29,6 +29,9 @@
     "name:fas_x_variant":[
         "\u0634\u0647\u0631 \u0627\u0644\u0628\u0631\u062a"
     ],
+    "name:ita_x_preferred":[
+        "Albert Town"
+    ],
     "name:nld_x_preferred":[
         "Albert Town"
     ],
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421176189,
-    "wof:lastmodified":1566724665,
+    "wof:lastmodified":1690937472,
     "wof:name":"Albert Town",
     "wof:parent_id":85672579,
     "wof:placetype":"locality",

--- a/data/421/176/787/421176787.geojson
+++ b/data/421/176/787/421176787.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Brown's Town"
+    ],
     "name:deu_x_preferred":[
         "Brown\u2019s Town"
     ],
@@ -26,7 +29,16 @@
     "name:fra_x_preferred":[
         "Brown's Town"
     ],
+    "name:heb_x_preferred":[
+        "\u05d1\u05e8\u05d0\u05d5\u05e0\u05e1 \u05d8\u05d0\u05d5\u05df"
+    ],
     "name:nld_x_preferred":[
+        "Brown's Town"
+    ],
+    "name:pol_x_preferred":[
+        "Brown\u2019s Town"
+    ],
+    "name:por_x_preferred":[
         "Brown's Town"
     ],
     "name:zho_x_preferred":[
@@ -81,7 +93,7 @@
         }
     ],
     "wof:id":421176787,
-    "wof:lastmodified":1566724665,
+    "wof:lastmodified":1690937473,
     "wof:name":"Browns Town",
     "wof:parent_id":85672599,
     "wof:placetype":"locality",

--- a/data/421/177/197/421177197.geojson
+++ b/data/421/177/197/421177197.geojson
@@ -17,10 +17,22 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Sandy Bay"
+    ],
+    "name:ceb_x_preferred":[
+        "Sandy Bay"
+    ],
+    "name:deu_x_preferred":[
+        "Sandy Bay"
+    ],
     "name:eng_x_preferred":[
         "Sandy Bay"
     ],
     "name:nld_x_preferred":[
+        "Sandy Bay"
+    ],
+    "name:swe_x_preferred":[
         "Sandy Bay"
     ],
     "name:und_x_variant":[
@@ -71,7 +83,7 @@
         }
     ],
     "wof:id":421177197,
-    "wof:lastmodified":1566724664,
+    "wof:lastmodified":1690937471,
     "wof:name":"Sandy Bay",
     "wof:parent_id":85672563,
     "wof:placetype":"locality",

--- a/data/421/179/055/421179055.geojson
+++ b/data/421/179/055/421179055.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ceb_x_preferred":[
+        "Lluidas Vale"
+    ],
     "name:eng_x_preferred":[
         "Luidas Vale"
     ],
@@ -24,6 +27,9 @@
         "Lluidas Vale"
     ],
     "name:nld_x_preferred":[
+        "Lluidas Vale"
+    ],
+    "name:swe_x_preferred":[
         "Lluidas Vale"
     ],
     "qs:gn_country":"JM",
@@ -71,7 +77,7 @@
         }
     ],
     "wof:id":421179055,
-    "wof:lastmodified":1566724664,
+    "wof:lastmodified":1690937471,
     "wof:name":"Lluidas Vale",
     "wof:parent_id":85672601,
     "wof:placetype":"locality",

--- a/data/421/179/059/421179059.geojson
+++ b/data/421/179/059/421179059.geojson
@@ -20,6 +20,9 @@
     "name:cat_x_preferred":[
         "Badia Esperan\u00e7a"
     ],
+    "name:ceb_x_preferred":[
+        "Hope Bay"
+    ],
     "name:deu_x_preferred":[
         "Hope Bay"
     ],
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":421179059,
-    "wof:lastmodified":1566724664,
+    "wof:lastmodified":1690937471,
     "wof:name":"Hope Bay",
     "wof:parent_id":85672591,
     "wof:placetype":"locality",

--- a/data/421/180/161/421180161.geojson
+++ b/data/421/180/161/421180161.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ceb_x_preferred":[
+        "Discovery Bay"
+    ],
     "name:eng_x_preferred":[
         "Discovery Bay"
     ],
@@ -24,6 +27,12 @@
         "\u30c7\u30a3\u30b9\u30ab\u30d0\u30ea\u30fc\u30fb\u30d9\u30a4"
     ],
     "name:nld_x_preferred":[
+        "Discovery Bay"
+    ],
+    "name:pol_x_preferred":[
+        "Discovery Bay"
+    ],
+    "name:swe_x_preferred":[
         "Discovery Bay"
     ],
     "name:und_x_variant":[
@@ -74,7 +83,7 @@
         }
     ],
     "wof:id":421180161,
-    "wof:lastmodified":1566724662,
+    "wof:lastmodified":1690937465,
     "wof:name":"Discovery Bay",
     "wof:parent_id":85672599,
     "wof:placetype":"locality",

--- a/data/421/180/285/421180285.geojson
+++ b/data/421/180/285/421180285.geojson
@@ -32,6 +32,9 @@
     "name:nld_x_preferred":[
         "Balaclava"
     ],
+    "name:pol_x_preferred":[
+        "Balaclava"
+    ],
     "name:swe_x_preferred":[
         "Balaclava"
     ],
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":421180285,
-    "wof:lastmodified":1566724662,
+    "wof:lastmodified":1690937466,
     "wof:name":"Balaclava",
     "wof:parent_id":85672569,
     "wof:placetype":"locality",

--- a/data/421/180/303/421180303.geojson
+++ b/data/421/180/303/421180303.geojson
@@ -26,6 +26,9 @@
     "name:deu_x_preferred":[
         "Darliston"
     ],
+    "name:ell_x_preferred":[
+        "\u039d\u03c4\u03ac\u03c1\u03bb\u03b9\u03c3\u03c4\u03bf\u03bd"
+    ],
     "name:eng_x_preferred":[
         "Darliston"
     ],
@@ -33,6 +36,9 @@
         "Darliston"
     ],
     "name:nld_x_preferred":[
+        "Darliston"
+    ],
+    "name:pol_x_preferred":[
         "Darliston"
     ],
     "name:swe_x_preferred":[
@@ -87,7 +93,7 @@
         }
     ],
     "wof:id":421180303,
-    "wof:lastmodified":1566724662,
+    "wof:lastmodified":1690937466,
     "wof:name":"Darliston",
     "wof:parent_id":85672583,
     "wof:placetype":"locality",

--- a/data/421/180/311/421180311.geojson
+++ b/data/421/180/311/421180311.geojson
@@ -17,10 +17,19 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ceb_x_preferred":[
+        "Petersfield"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a0\u03af\u03c4\u03b5\u03c1\u03c3\u03c6\u03b9\u03bb\u03bd\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Petersfield"
     ],
     "name:nld_x_preferred":[
+        "Petersfield"
+    ],
+    "name:swe_x_preferred":[
         "Petersfield"
     ],
     "qs:gn_country":"JM",
@@ -70,7 +79,7 @@
         }
     ],
     "wof:id":421180311,
-    "wof:lastmodified":1566724662,
+    "wof:lastmodified":1690937466,
     "wof:name":"Petersfield",
     "wof:parent_id":85672583,
     "wof:placetype":"locality",

--- a/data/421/182/087/421182087.geojson
+++ b/data/421/182/087/421182087.geojson
@@ -32,6 +32,9 @@
     "name:bel_x_preferred":[
         "\u0420\u0430\u0439"
     ],
+    "name:bel_x_variant":[
+        "\u0440\u0430\u0439"
+    ],
     "name:bos_x_preferred":[
         "Raj"
     ],
@@ -47,11 +50,17 @@
     "name:ces_x_preferred":[
         "R\u00e1j"
     ],
+    "name:chv_x_preferred":[
+        "\u00c7\u0103\u0442\u043c\u0430\u0445"
+    ],
     "name:ckb_x_preferred":[
         "\u067e\u0627\u0631\u062f\u06ce\u0632"
     ],
     "name:cos_x_preferred":[
         "Paradisu"
+    ],
+    "name:cym_x_preferred":[
+        "paradwys"
     ],
     "name:dan_x_preferred":[
         "Paradis"
@@ -71,6 +80,9 @@
     "name:epo_x_preferred":[
         "Paradizo"
     ],
+    "name:est_x_preferred":[
+        "Paradiis"
+    ],
     "name:eus_x_preferred":[
         "Paradisu"
     ],
@@ -79,6 +91,9 @@
     ],
     "name:fin_x_preferred":[
         "Paratiisi"
+    ],
+    "name:fin_x_variant":[
+        "paratiisi"
     ],
     "name:fra_x_preferred":[
         "paradis"
@@ -92,6 +107,9 @@
     "name:gla_x_preferred":[
         "P\u00e0rras"
     ],
+    "name:hau_x_preferred":[
+        "Aljannah"
+    ],
     "name:heb_x_preferred":[
         "\u05d2\u05df \u05e2\u05d3\u05df"
     ],
@@ -101,14 +119,23 @@
     "name:hrv_x_preferred":[
         "Raj"
     ],
+    "name:hun_x_preferred":[
+        "paradicsom"
+    ],
     "name:hye_x_preferred":[
         "\u0534\u0580\u0561\u056d\u057f"
     ],
     "name:ido_x_preferred":[
         "Paradizo"
     ],
+    "name:ina_x_preferred":[
+        "Paradiso"
+    ],
     "name:ind_x_preferred":[
         "Firdaus"
+    ],
+    "name:inh_x_preferred":[
+        "\u042f\u043b\u0441\u043c\u0430\u043b\u0435"
     ],
     "name:ita_x_preferred":[
         "paradiso"
@@ -137,6 +164,9 @@
     "name:lit_x_preferred":[
         "Rojus"
     ],
+    "name:mkd_x_preferred":[
+        "\u0420\u0430\u0458"
+    ],
     "name:mlg_x_preferred":[
         "Paradisa"
     ],
@@ -164,6 +194,9 @@
     "name:pol_x_preferred":[
         "Raj"
     ],
+    "name:pol_x_variant":[
+        "raj"
+    ],
     "name:por_x_preferred":[
         "para\u00edso"
     ],
@@ -175,6 +208,12 @@
     ],
     "name:rus_x_preferred":[
         "\u0420\u0430\u0439"
+    ],
+    "name:rus_x_variant":[
+        "\u0440\u0430\u0439"
+    ],
+    "name:sah_x_preferred":[
+        "\u042b\u0440\u0430\u0439"
     ],
     "name:slk_x_preferred":[
         "Raj"
@@ -200,6 +239,9 @@
     "name:swe_x_preferred":[
         "Paradis"
     ],
+    "name:swe_x_variant":[
+        "paradis"
+    ],
     "name:tat_x_preferred":[
         "\u0497\u04d9\u043d\u043d\u04d9\u0442"
     ],
@@ -212,8 +254,14 @@
     "name:ukr_x_preferred":[
         "\u0420\u0430\u0439"
     ],
+    "name:ukr_x_variant":[
+        "\u0440\u0430\u0439"
+    ],
     "name:urd_x_preferred":[
         "\u0641\u0631\u062f\u0648\u0633"
+    ],
+    "name:wuu_x_preferred":[
+        "\u4e50\u56ed"
     ],
     "name:zho_x_preferred":[
         "\u6a02\u5712"
@@ -262,7 +310,7 @@
         }
     ],
     "wof:id":421182087,
-    "wof:lastmodified":1566724664,
+    "wof:lastmodified":1690937472,
     "wof:name":"Paradise",
     "wof:parent_id":85672583,
     "wof:placetype":"locality",

--- a/data/421/182/293/421182293.geojson
+++ b/data/421/182/293/421182293.geojson
@@ -20,11 +20,20 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u0631\u062a\u0645\u0648\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u0631\u062a\u0645\u0648\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "Portmore"
+    ],
     "name:ben_x_preferred":[
         "\u09aa\u09cb\u09b0\u09cd\u099f\u09cd\u09ae\u09cb\u09b0\u09c7"
     ],
     "name:bul_x_preferred":[
         "\u041f\u043e\u0440\u0442\u043c\u043e\u0440\u0435"
+    ],
+    "name:cat_x_preferred":[
+        "Portmore"
     ],
     "name:ceb_x_preferred":[
         "Portmore"
@@ -59,6 +68,12 @@
     "name:fra_x_preferred":[
         "Portmore"
     ],
+    "name:frr_x_preferred":[
+        "Portmore"
+    ],
+    "name:gle_x_preferred":[
+        "Portmore"
+    ],
     "name:guj_x_preferred":[
         "\u0aaa\u0acb\u0ab0\u0acd\u0a9f\u0aae\u0acb\u0ab0"
     ],
@@ -67,6 +82,9 @@
     ],
     "name:hin_x_preferred":[
         "\u092a\u094b\u0930\u094d\u091f\u094b\u0930"
+    ],
+    "name:hye_x_preferred":[
+        "\u054a\u0578\u0580\u057f\u0574\u0578\u0580"
     ],
     "name:ind_x_preferred":[
         "Portmore"
@@ -131,6 +149,9 @@
     "name:tha_x_preferred":[
         "\u0e1e\u0e2d\u0e23\u0e4c\u0e17\u0e21\u0e2d\u0e23\u0e4c"
     ],
+    "name:tha_x_variant":[
+        "\u0e1e\u0e2d\u0e23\u0e4c\u0e15\u0e21\u0e2d\u0e23\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Portmore"
     ],
@@ -140,7 +161,13 @@
     "name:urd_x_preferred":[
         "\u067e\u0648\u0631\u062a\u0645\u0648\u0631\u06cc"
     ],
+    "name:vec_x_preferred":[
+        "Portmore"
+    ],
     "name:vie_x_preferred":[
+        "Portmore"
+    ],
+    "name:war_x_preferred":[
         "Portmore"
     ],
     "name:zho_x_preferred":[
@@ -194,7 +221,7 @@
         }
     ],
     "wof:id":421182293,
-    "wof:lastmodified":1566724664,
+    "wof:lastmodified":1690937471,
     "wof:name":"Portmore",
     "wof:parent_id":85672601,
     "wof:placetype":"locality",

--- a/data/421/184/755/421184755.geojson
+++ b/data/421/184/755/421184755.geojson
@@ -20,6 +20,9 @@
     "name:afr_x_preferred":[
         "Hoop"
     ],
+    "name:aka_x_preferred":[
+        "Anidaso"
+    ],
     "name:ara_x_preferred":[
         "\u0623\u0645\u0644"
     ],
@@ -29,8 +32,17 @@
     "name:aze_x_preferred":[
         "\u00dcmid"
     ],
+    "name:bcl_x_preferred":[
+        "Paglaom"
+    ],
     "name:bel_x_preferred":[
         "\u043d\u0430\u0434\u0437\u0435\u044f"
+    ],
+    "name:ben_x_preferred":[
+        "\u0986\u09b6\u09be"
+    ],
+    "name:bos_x_preferred":[
+        "Nada"
     ],
     "name:bpy_x_preferred":[
         "\u098f\u09b8\u09aa\u09c7\u09b0\u09be\u09a8\u09cd\u09b8\u09be"
@@ -44,17 +56,32 @@
     "name:ces_x_preferred":[
         "nad\u011bje"
     ],
+    "name:chv_x_preferred":[
+        "\u0421\u0443\u043d\u0103\u043c"
+    ],
+    "name:ckb_x_preferred":[
+        "\u06be\u06cc\u0648\u0627"
+    ],
     "name:cor_x_preferred":[
         "Yr H\u00f4b"
     ],
+    "name:csb_x_preferred":[
+        "n\u00f4dzeja"
+    ],
     "name:cym_x_preferred":[
         "Gobaith"
+    ],
+    "name:cym_x_variant":[
+        "gobaith"
     ],
     "name:dan_x_preferred":[
         "h\u00e5b"
     ],
     "name:deu_x_preferred":[
         "Hoffnung"
+    ],
+    "name:dsb_x_preferred":[
+        "na\u017aeja"
     ],
     "name:ell_x_preferred":[
         "\u03b5\u03bb\u03c0\u03af\u03b4\u03b1"
@@ -80,6 +107,12 @@
     "name:fra_x_preferred":[
         "espoir"
     ],
+    "name:fry_x_preferred":[
+        "Hoop"
+    ],
+    "name:gle_x_preferred":[
+        "d\u00f3chas"
+    ],
     "name:glg_x_preferred":[
         "Esperanza"
     ],
@@ -98,11 +131,17 @@
     "name:hrv_x_preferred":[
         "Nada"
     ],
+    "name:hsb_x_preferred":[
+        "nad\u017aija"
+    ],
     "name:hun_x_preferred":[
         "rem\u00e9ny"
     ],
     "name:hye_x_preferred":[
         "\u0540\u0578\u0582\u0575\u057d"
+    ],
+    "name:ibo_x_preferred":[
+        "nchekwube"
     ],
     "name:ido_x_preferred":[
         "Espero"
@@ -112,6 +151,9 @@
     ],
     "name:ita_x_preferred":[
         "speranza"
+    ],
+    "name:jav_x_preferred":[
+        "Pangarep-arep"
     ],
     "name:jpn_x_preferred":[
         "\u5e0c\u671b"
@@ -131,6 +173,9 @@
     "name:lat_x_preferred":[
         "Spes"
     ],
+    "name:lav_x_preferred":[
+        "cer\u012bba"
+    ],
     "name:lim_x_preferred":[
         "Haop"
     ],
@@ -140,11 +185,17 @@
     "name:ltz_x_preferred":[
         "Hoffnung"
     ],
+    "name:mkd_x_preferred":[
+        "\u043d\u0430\u0434\u0435\u0436"
+    ],
     "name:new_x_preferred":[
         "\u0906\u0936\u093e"
     ],
     "name:nld_x_preferred":[
         "Hoop"
+    ],
+    "name:nld_x_variant":[
+        "hoop"
     ],
     "name:nno_x_preferred":[
         "von"
@@ -154,6 +205,9 @@
     ],
     "name:pan_x_preferred":[
         "\u0a09\u0a2e\u0a40\u0a26"
+    ],
+    "name:pnb_x_preferred":[
+        "\u0627\u0645\u06cc\u062f"
     ],
     "name:pol_x_preferred":[
         "nadzieja"
@@ -167,6 +221,9 @@
     "name:rus_x_preferred":[
         "\u043d\u0430\u0434\u0435\u0436\u0434\u0430"
     ],
+    "name:sat_x_preferred":[
+        "\u1c5f\u1c65\u1c77\u1c5f"
+    ],
     "name:scn_x_preferred":[
         "Spiranza"
     ],
@@ -178,6 +235,9 @@
     ],
     "name:slv_x_preferred":[
         "Upanje"
+    ],
+    "name:slv_x_variant":[
+        "upanje"
     ],
     "name:spa_x_preferred":[
         "esperanza"
@@ -191,11 +251,17 @@
     "name:swa_x_preferred":[
         "Tumaini"
     ],
+    "name:swe_x_preferred":[
+        "hopp"
+    ],
     "name:tel_x_preferred":[
         "\u0c06\u0c36"
     ],
     "name:tur_x_preferred":[
         "Umut"
+    ],
+    "name:twi_x_preferred":[
+        "Anidaso"
     ],
     "name:ukr_x_preferred":[
         "\u043d\u0430\u0434\u0456\u044f"
@@ -256,7 +322,7 @@
         }
     ],
     "wof:id":421184755,
-    "wof:lastmodified":1566724664,
+    "wof:lastmodified":1690937470,
     "wof:name":"Hope",
     "wof:parent_id":85672609,
     "wof:placetype":"locality",

--- a/data/421/185/207/421185207.geojson
+++ b/data/421/185/207/421185207.geojson
@@ -22,6 +22,9 @@
     "name:eng_x_preferred":[
         "Cross Roads"
     ],
+    "name:nld_x_preferred":[
+        "Cross Roads"
+    ],
     "qs:gn_country":"JM",
     "qs:gn_fcode":"PPLX",
     "qs:gn_id":3490791,
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":421185207,
-    "wof:lastmodified":1566724665,
+    "wof:lastmodified":1690937473,
     "wof:name":"Cross Roads",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/186/515/421186515.geojson
+++ b/data/421/186/515/421186515.geojson
@@ -34,11 +34,23 @@
     "name:arg_x_preferred":[
         "Kingston"
     ],
+    "name:ary_x_preferred":[
+        "\u0643\u064a\u0646\u06ad\u0633\u0637\u0648\u0646"
+    ],
+    "name:arz_x_preferred":[
+        "\u0643\u064a\u0646\u062c\u0633\u062a\u0648\u0646"
+    ],
     "name:ast_x_preferred":[
+        "Kingston"
+    ],
+    "name:avk_x_preferred":[
         "Kingston"
     ],
     "name:aze_x_preferred":[
         "Kinqston"
+    ],
+    "name:ban_x_preferred":[
+        "Kingston"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041a\u0456\u043d\u0433\u0441\u0442\u0430\u043d"
@@ -118,6 +130,9 @@
     "name:fra_x_preferred":[
         "Kingston"
     ],
+    "name:frr_x_preferred":[
+        "Kingston"
+    ],
     "name:fry_x_preferred":[
         "Kingston"
     ],
@@ -144,6 +159,9 @@
     ],
     "name:hat_x_preferred":[
         "Kinst\u00f2n"
+    ],
+    "name:hau_x_preferred":[
+        "Kingston"
     ],
     "name:heb_x_preferred":[
         "\u05e7\u05d9\u05e0\u05d2\u05e1\u05d8\u05d5\u05df"
@@ -217,6 +235,9 @@
     "name:kor_x_preferred":[
         "\ud0b9\uc2a4\ud134"
     ],
+    "name:kur_x_preferred":[
+        "Kingston"
+    ],
     "name:lat_x_preferred":[
         "Regiopolis"
     ],
@@ -224,6 +245,9 @@
         "Kingstona"
     ],
     "name:lfn_x_preferred":[
+        "Kingston"
+    ],
+    "name:lij_x_preferred":[
         "Kingston"
     ],
     "name:lit_x_preferred":[
@@ -244,11 +268,17 @@
     "name:mar_x_preferred":[
         "\u0915\u093f\u0902\u0917\u094d\u0938\u094d\u091f\u0928"
     ],
+    "name:mdf_x_preferred":[
+        "\u041a\u0438\u043d\u0433\u0441\u0442\u043e\u043d"
+    ],
     "name:mkd_x_preferred":[
         "\u041a\u0438\u043d\u0433\u0441\u0442\u043e\u043d"
     ],
     "name:mon_x_preferred":[
         "\u041a\u0438\u043d\u0433\u0441\u0442\u043e\u043d"
+    ],
+    "name:mos_x_preferred":[
+        "Kingston"
     ],
     "name:msa_x_preferred":[
         "Kingston"
@@ -304,6 +334,9 @@
     "name:ron_x_preferred":[
         "Kingston"
     ],
+    "name:rue_x_preferred":[
+        "\u041a\u0438\u043d\u0433\u0441\u0442\u043e\u043d"
+    ],
     "name:rus_x_preferred":[
         "\u041a\u0438\u043d\u0433\u0441\u0442\u043e\u043d"
     ],
@@ -323,6 +356,15 @@
         "Kingston"
     ],
     "name:slv_x_preferred":[
+        "Kingston"
+    ],
+    "name:sme_x_preferred":[
+        "Kingston"
+    ],
+    "name:smn_x_preferred":[
+        "Kingston"
+    ],
+    "name:sms_x_preferred":[
         "Kingston"
     ],
     "name:sna_x_preferred":[
@@ -358,6 +400,9 @@
     "name:tel_x_preferred":[
         "\u0c15\u0c3f\u0c02\u0c17\u0c4d\u0c38\u0c4d\u0c1f\u0c28\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u041a\u0438\u043d\u0433\u0441\u0442\u043e\u043d"
+    ],
     "name:tgl_x_preferred":[
         "Kingston"
     ],
@@ -370,6 +415,9 @@
     "name:tur_x_preferred":[
         "Kingston"
     ],
+    "name:udm_x_preferred":[
+        "\u041a\u0438\u043d\u0433\u0441\u0442\u043e\u043d"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u0456\u043d\u0433\u0441\u0442\u043e\u043d"
     ],
@@ -377,6 +425,9 @@
         "\u06a9\u0646\u06af\u0633\u0679\u0646"
     ],
     "name:uzb_x_preferred":[
+        "Kingston"
+    ],
+    "name:vec_x_preferred":[
         "Kingston"
     ],
     "name:vep_x_preferred":[
@@ -394,6 +445,9 @@
     "name:wln_x_preferred":[
         "Kingston"
     ],
+    "name:wuu_x_preferred":[
+        "\u91d1\u65af\u6566"
+    ],
     "name:xmf_x_preferred":[
         "\u10d9\u10d8\u10dc\u10d2\u10e1\u10e2\u10dd\u10dc\u10d8"
     ],
@@ -405,6 +459,9 @@
     ],
     "name:zho_x_preferred":[
         "\u4eac\u65af\u6566"
+    ],
+    "name:zho_x_variant":[
+        "\u91d1\u65af\u6566"
     ],
     "ne:ADM0CAP":1.0,
     "ne:ADM0NAME":"Jamaica",
@@ -556,7 +613,7 @@
         }
     ],
     "wof:id":421186515,
-    "wof:lastmodified":1636495994,
+    "wof:lastmodified":1690937467,
     "wof:name":"Kingston",
     "wof:parent_id":85672609,
     "wof:placetype":"locality",

--- a/data/421/186/595/421186595.geojson
+++ b/data/421/186/595/421186595.geojson
@@ -23,8 +23,17 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u0631\u062a \u0645\u0627\u0631\u064a\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u0631\u062a \u0645\u0627\u0631\u064a\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Port Maria"
+    ],
     "name:ben_x_preferred":[
         "\u09aa\u09cb\u09b0\u09cd\u099f \u09ae\u09be\u09b0\u09bf\u09df\u09be"
+    ],
+    "name:bul_x_preferred":[
+        "\u041f\u043e\u0440\u0442 \u041c\u0430\u0440\u0438\u044f"
     ],
     "name:ceb_x_preferred":[
         "Port Maria"
@@ -95,6 +104,9 @@
     "name:tur_x_preferred":[
         "Port Maria"
     ],
+    "name:ukr_x_preferred":[
+        "\u041f\u043e\u0440\u0442-\u041c\u0430\u0440\u0456\u044f"
+    ],
     "name:urd_x_preferred":[
         "\u067e\u0648\u0631\u0679 \u0645\u0627\u0631\u06cc\u0627"
     ],
@@ -156,7 +168,7 @@
         }
     ],
     "wof:id":421186595,
-    "wof:lastmodified":1636495994,
+    "wof:lastmodified":1690937467,
     "wof:name":"Port Maria",
     "wof:parent_id":85672605,
     "wof:placetype":"locality",

--- a/data/421/191/973/421191973.geojson
+++ b/data/421/191/973/421191973.geojson
@@ -29,14 +29,23 @@
     "name:cat_x_variant":[
         "priorat"
     ],
+    "name:ces_x_preferred":[
+        "p\u0159evorstv\u00ed"
+    ],
     "name:cym_x_preferred":[
         "Priordy"
     ],
     "name:cym_x_variant":[
         "priordy"
     ],
+    "name:dan_x_preferred":[
+        "kloster"
+    ],
     "name:deu_x_preferred":[
         "Priorat"
+    ],
+    "name:ell_x_preferred":[
+        "\u03c0\u03c1\u03bf\u03c3\u03b5\u03c5\u03c7\u03b7\u03c4\u03ae\u03c1\u03b9\u03bf"
     ],
     "name:eng_x_preferred":[
         "priory"
@@ -52,6 +61,9 @@
     ],
     "name:gle_x_preferred":[
         "Pri\u00f3ireacht"
+    ],
+    "name:gle_x_variant":[
+        "pri\u00f3ireacht"
     ],
     "name:hun_x_preferred":[
         "perjels\u00e9g"
@@ -110,6 +122,9 @@
     "name:swe_x_preferred":[
         "priorskloster"
     ],
+    "name:ukr_x_preferred":[
+        "\u043f\u0440\u0456\u043e\u0440\u0430\u0442"
+    ],
     "name:zho_x_preferred":[
         "\u5c0f\u96b1\u4fee\u9662"
     ],
@@ -157,7 +172,7 @@
         }
     ],
     "wof:id":421191973,
-    "wof:lastmodified":1566724663,
+    "wof:lastmodified":1690937468,
     "wof:name":"Priory",
     "wof:parent_id":85672599,
     "wof:placetype":"locality",

--- a/data/421/192/085/421192085.geojson
+++ b/data/421/192/085/421192085.geojson
@@ -17,13 +17,28 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:bul_x_preferred":[
+        "\u041c\u0430\u043d\u0447\u0438\u043e\u043d\u0435\u0430\u043b"
+    ],
+    "name:ceb_x_preferred":[
+        "Manchioneal"
+    ],
     "name:eng_x_preferred":[
+        "Manchioneal"
+    ],
+    "name:ita_x_preferred":[
         "Manchioneal"
     ],
     "name:jpn_x_preferred":[
         "\u30de\u30f3\u30c1\u30aa\u30cd\u30a2\u30eb"
     ],
     "name:nld_x_preferred":[
+        "Manchioneal"
+    ],
+    "name:pol_x_preferred":[
+        "Manchioneal"
+    ],
+    "name:swe_x_preferred":[
         "Manchioneal"
     ],
     "qs:gn_country":"JM",
@@ -70,7 +85,7 @@
         }
     ],
     "wof:id":421192085,
-    "wof:lastmodified":1566724660,
+    "wof:lastmodified":1690937462,
     "wof:name":"Manchioneal",
     "wof:parent_id":85672569,
     "wof:placetype":"locality",

--- a/data/421/192/091/421192091.geojson
+++ b/data/421/192/091/421192091.geojson
@@ -17,13 +17,28 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:bul_x_preferred":[
+        "\u041c\u0430\u043d\u0447\u0438\u043e\u043d\u0435\u0430\u043b"
+    ],
+    "name:ceb_x_preferred":[
+        "Manchioneal"
+    ],
     "name:eng_x_preferred":[
+        "Manchioneal"
+    ],
+    "name:ita_x_preferred":[
         "Manchioneal"
     ],
     "name:jpn_x_preferred":[
         "\u30de\u30f3\u30c1\u30aa\u30cd\u30a2\u30eb"
     ],
     "name:nld_x_preferred":[
+        "Manchioneal"
+    ],
+    "name:pol_x_preferred":[
+        "Manchioneal"
+    ],
+    "name:swe_x_preferred":[
         "Manchioneal"
     ],
     "qs:gn_country":"JM",
@@ -71,7 +86,7 @@
         }
     ],
     "wof:id":421192091,
-    "wof:lastmodified":1566724660,
+    "wof:lastmodified":1690937462,
     "wof:name":"Manchioneal",
     "wof:parent_id":85672591,
     "wof:placetype":"locality",

--- a/data/421/193/065/421193065.geojson
+++ b/data/421/193/065/421193065.geojson
@@ -23,6 +23,9 @@
     "name:deu_x_preferred":[
         "Bluefields"
     ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03bb\u03bf\u03cd\u03c6\u03b9\u03bb\u03bd\u03c4\u03c2"
+    ],
     "name:eng_x_preferred":[
         "Bluefields"
     ],
@@ -33,6 +36,9 @@
         "Bluefields"
     ],
     "name:nld_x_preferred":[
+        "Bluefields"
+    ],
+    "name:pol_x_preferred":[
         "Bluefields"
     ],
     "name:swe_x_preferred":[
@@ -84,7 +90,7 @@
         }
     ],
     "wof:id":421193065,
-    "wof:lastmodified":1636495993,
+    "wof:lastmodified":1690937464,
     "wof:name":"Bluefields",
     "wof:parent_id":85672583,
     "wof:placetype":"locality",

--- a/data/421/193/449/421193449.geojson
+++ b/data/421/193/449/421193449.geojson
@@ -17,10 +17,19 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:bul_x_preferred":[
+        "\u0414\u0430\u043b\u0432\u0435\u0439"
+    ],
+    "name:ceb_x_preferred":[
+        "Dalvey"
+    ],
     "name:eng_x_preferred":[
         "Dalvey"
     ],
     "name:nld_x_preferred":[
+        "Dalvey"
+    ],
+    "name:swe_x_preferred":[
         "Dalvey"
     ],
     "name:und_x_variant":[
@@ -71,7 +80,7 @@
         }
     ],
     "wof:id":421193449,
-    "wof:lastmodified":1566724661,
+    "wof:lastmodified":1690937463,
     "wof:name":"Dalvey",
     "wof:parent_id":85672615,
     "wof:placetype":"locality",

--- a/data/421/194/571/421194571.geojson
+++ b/data/421/194/571/421194571.geojson
@@ -23,23 +23,44 @@
     "name:ara_x_preferred":[
         "\u0635\u0646\u062f\u0648\u0642"
     ],
+    "name:arg_x_preferred":[
+        "Caixa"
+    ],
     "name:bak_x_preferred":[
         "\u04a0\u0443\u043c\u0442\u0430"
     ],
     "name:bel_x_preferred":[
         "\u0441\u043a\u0440\u044b\u043d\u044f"
     ],
+    "name:ben_x_preferred":[
+        "\u09ac\u09be\u0995\u09cd\u09b8"
+    ],
+    "name:bjn_x_preferred":[
+        "Kutak"
+    ],
     "name:bre_x_preferred":[
         "Kased"
     ],
+    "name:bul_x_preferred":[
+        "\u041a\u0443\u0442\u0438\u044f"
+    ],
     "name:cat_x_preferred":[
         "Caixa"
+    ],
+    "name:cat_x_variant":[
+        "caixa"
     ],
     "name:cdo_x_preferred":[
         "\u0102k-\u0103k"
     ],
     "name:ces_x_preferred":[
         "bedna"
+    ],
+    "name:chv_x_preferred":[
+        "\u041a\u0443\u043d\u0442\u0103\u043a"
+    ],
+    "name:dag_x_preferred":[
+        "adaka"
     ],
     "name:dan_x_preferred":[
         "kasse"
@@ -56,8 +77,14 @@
     "name:epo_x_preferred":[
         "kesto"
     ],
+    "name:est_x_preferred":[
+        "Kast"
+    ],
     "name:eus_x_preferred":[
         "kaxa"
+    ],
+    "name:eus_x_variant":[
+        "kutxa"
     ],
     "name:ewe_x_preferred":[
         "Adaka"
@@ -65,17 +92,26 @@
     "name:fas_x_preferred":[
         "\u062c\u0639\u0628\u0647"
     ],
+    "name:fij_x_preferred":[
+        "Kato"
+    ],
     "name:fin_x_preferred":[
         "laatikko"
     ],
     "name:fra_x_preferred":[
         "caisse"
     ],
+    "name:fra_x_variant":[
+        "bo\u00eete"
+    ],
     "name:gla_x_preferred":[
         "Bogsa"
     ],
     "name:gle_x_preferred":[
         "Bosca"
+    ],
+    "name:gur_x_preferred":[
+        "Daka"
     ],
     "name:hat_x_preferred":[
         "Bwat"
@@ -86,11 +122,20 @@
     "name:hin_x_preferred":[
         "m"
     ],
+    "name:hun_x_preferred":[
+        "doboz"
+    ],
+    "name:hye_x_preferred":[
+        "\u0531\u0580\u056f\u0572"
+    ],
     "name:ido_x_preferred":[
         "Buxo"
     ],
     "name:ind_x_preferred":[
         "Kotak"
+    ],
+    "name:ind_x_variant":[
+        "kotak"
     ],
     "name:ita_x_preferred":[
         "scatola"
@@ -113,6 +158,9 @@
     "name:lav_x_preferred":[
         "Kaste"
     ],
+    "name:mkd_x_preferred":[
+        "\u043a\u0443\u0442\u0438\u0458\u0430"
+    ],
     "name:msa_x_preferred":[
         "Kotak"
     ],
@@ -134,11 +182,20 @@
     "name:pol_x_preferred":[
         "Skrzynia"
     ],
+    "name:por_x_preferred":[
+        "caixa"
+    ],
     "name:ron_x_preferred":[
         "Cutie"
     ],
     "name:rus_x_preferred":[
         "\u041a\u043e\u0440\u043e\u0431\u043a\u0430"
+    ],
+    "name:rus_x_variant":[
+        "\u043a\u043e\u0440\u043e\u0431\u043a\u0430"
+    ],
+    "name:sat_x_preferred":[
+        "\u1c75\u1c5f\u1c60\u1c65\u1c5a"
     ],
     "name:scn_x_preferred":[
         "Cascia"
@@ -146,14 +203,29 @@
     "name:sco_x_preferred":[
         "box"
     ],
+    "name:slv_x_preferred":[
+        "\u0161katla"
+    ],
+    "name:sna_x_preferred":[
+        "Bhokisi"
+    ],
     "name:spa_x_preferred":[
         "caja"
+    ],
+    "name:sqi_x_preferred":[
+        "Kuti"
+    ],
+    "name:srp_x_preferred":[
+        "\u043a\u0443\u0442\u0438\u0458\u0430"
     ],
     "name:swa_x_preferred":[
         "Boksi"
     ],
     "name:swe_x_preferred":[
         "L\u00e5da"
+    ],
+    "name:swe_x_variant":[
+        "l\u00e5da"
     ],
     "name:tam_x_preferred":[
         "\u0baa\u0bc6\u0b9f\u0bcd\u0b9f\u0bbf"
@@ -164,6 +236,9 @@
     "name:tgk_x_preferred":[
         "\u049a\u0443\u0442\u0442\u04e3"
     ],
+    "name:tgl_x_preferred":[
+        "Kahon"
+    ],
     "name:tha_x_preferred":[
         "\u0e01\u0e25\u0e48\u0e2d\u0e07"
     ],
@@ -172,6 +247,15 @@
     ],
     "name:ukr_x_preferred":[
         "\u041a\u043e\u0440\u043e\u0431\u043a\u0430"
+    ],
+    "name:ukr_x_variant":[
+        "\u043a\u043e\u0440\u043e\u0431\u043a\u0430"
+    ],
+    "name:uzb_x_preferred":[
+        "Quti"
+    ],
+    "name:vls_x_preferred":[
+        "Doze"
     ],
     "name:xho_x_preferred":[
         "Ibhokisi"
@@ -226,7 +310,7 @@
         }
     ],
     "wof:id":421194571,
-    "wof:lastmodified":1566724661,
+    "wof:lastmodified":1690937463,
     "wof:name":"Box",
     "wof:parent_id":85672573,
     "wof:placetype":"locality",

--- a/data/421/194/885/421194885.geojson
+++ b/data/421/194/885/421194885.geojson
@@ -20,14 +20,23 @@
     "name:deu_x_preferred":[
         "August Town FC"
     ],
+    "name:deu_x_variant":[
+        "August Town"
+    ],
     "name:eng_x_preferred":[
         "August Town F.C."
     ],
     "name:fra_x_preferred":[
         "August Town F.C."
     ],
+    "name:fra_x_variant":[
+        "August Town"
+    ],
     "name:nld_x_preferred":[
         "August Town FC"
+    ],
+    "name:nld_x_variant":[
+        "August Town"
     ],
     "name:spa_x_preferred":[
         "August Town F.C."
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":421194885,
-    "wof:lastmodified":1566724661,
+    "wof:lastmodified":1690937463,
     "wof:name":"August Town",
     "wof:parent_id":85672609,
     "wof:placetype":"locality",

--- a/data/421/194/889/421194889.geojson
+++ b/data/421/194/889/421194889.geojson
@@ -35,6 +35,9 @@
     "name:deu_x_preferred":[
         "Barbakane"
     ],
+    "name:ell_x_preferred":[
+        "\u03c0\u03b1\u03c1\u03b1\u03c4\u03b7\u03c1\u03b7\u03c4\u03ae\u03c1\u03b9\u03bf"
+    ],
     "name:eng_x_preferred":[
         "barbican"
     ],
@@ -44,11 +47,20 @@
     "name:est_x_preferred":[
         "Barbakaan"
     ],
+    "name:eus_x_preferred":[
+        "Barbakana"
+    ],
     "name:fas_x_preferred":[
         "\u0628\u0631\u062c \u062f\u06cc\u062f\u0628\u0627\u0646"
     ],
+    "name:fin_x_preferred":[
+        "Barbakaani"
+    ],
     "name:fra_x_preferred":[
         "barbacane"
+    ],
+    "name:gle_x_preferred":[
+        "barbac\u00e1n"
     ],
     "name:heb_x_preferred":[
         "\u05d1\u05e8\u05d1\u05d9\u05e7\u05df"
@@ -83,6 +95,12 @@
     "name:nld_x_preferred":[
         "Barbacane"
     ],
+    "name:nld_x_variant":[
+        "barbacane"
+    ],
+    "name:nob_x_preferred":[
+        "barbakan"
+    ],
     "name:pol_x_preferred":[
         "barbakan"
     ],
@@ -107,8 +125,14 @@
     "name:spa_x_preferred":[
         "Barbacana"
     ],
+    "name:spa_x_variant":[
+        "barbacana"
+    ],
     "name:srp_x_preferred":[
         "\u0431\u0430\u0440\u0431\u0430\u043a\u0430\u043d"
+    ],
+    "name:tur_x_preferred":[
+        "Barbakan"
     ],
     "name:ukr_x_preferred":[
         "\u0411\u0430\u0440\u0431\u0430\u043a\u0430\u043d"
@@ -163,7 +187,7 @@
         }
     ],
     "wof:id":421194889,
-    "wof:lastmodified":1566724661,
+    "wof:lastmodified":1690937463,
     "wof:name":"Barbican",
     "wof:parent_id":85672563,
     "wof:placetype":"locality",

--- a/data/421/197/563/421197563.geojson
+++ b/data/421/197/563/421197563.geojson
@@ -17,10 +17,16 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ceb_x_preferred":[
+        "Trinity Ville"
+    ],
     "name:eng_x_preferred":[
         "Trinity Ville"
     ],
     "name:nld_x_preferred":[
+        "Trinity Ville"
+    ],
+    "name:swe_x_preferred":[
         "Trinity Ville"
     ],
     "qs:gn_country":"JM",
@@ -68,7 +74,7 @@
         }
     ],
     "wof:id":421197563,
-    "wof:lastmodified":1566724663,
+    "wof:lastmodified":1690937469,
     "wof:name":"Trinity Ville",
     "wof:parent_id":85672615,
     "wof:placetype":"locality",

--- a/data/421/197/565/421197565.geojson
+++ b/data/421/197/565/421197565.geojson
@@ -59,7 +59,13 @@
     "name:hbs_x_preferred":[
         "Port Royal"
     ],
+    "name:heb_x_preferred":[
+        "\u05e4\u05d5\u05e8\u05d8 \u05e8\u05d5\u05d9\u05d0\u05dc"
+    ],
     "name:hrv_x_preferred":[
+        "Port Royal"
+    ],
+    "name:hun_x_preferred":[
         "Port Royal"
     ],
     "name:hye_x_preferred":[
@@ -79,6 +85,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud3ec\ud2b8\ub85c\uc5f4"
+    ],
+    "name:msa_x_preferred":[
+        "Port Royal"
     ],
     "name:nld_x_preferred":[
         "Port Royal"
@@ -118,6 +127,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u041f\u043e\u0440\u0442-\u0420\u043e\u0439\u0430\u043b"
+    ],
+    "name:ukr_x_variant":[
+        "\u041f\u043e\u0440\u0442-\u0420\u043e\u044f\u043b\u044c"
     ],
     "name:vie_x_preferred":[
         "Port Royal"
@@ -170,7 +182,7 @@
         }
     ],
     "wof:id":421197565,
-    "wof:lastmodified":1566724663,
+    "wof:lastmodified":1690937469,
     "wof:name":"Port Royal",
     "wof:parent_id":85672587,
     "wof:placetype":"locality",

--- a/data/421/198/467/421198467.geojson
+++ b/data/421/198/467/421198467.geojson
@@ -17,10 +17,16 @@
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ceb_x_preferred":[
+        "Coleyville"
+    ],
     "name:eng_x_preferred":[
         "Coleyville"
     ],
     "name:nld_x_preferred":[
+        "Coleyville"
+    ],
+    "name:swe_x_preferred":[
         "Coleyville"
     ],
     "qs:gn_country":"JM",
@@ -75,7 +81,7 @@
         }
     ],
     "wof:id":421198467,
-    "wof:lastmodified":1566724663,
+    "wof:lastmodified":1690937468,
     "wof:name":"Coleyville",
     "wof:parent_id":-4,
     "wof:placetype":"locality",

--- a/data/421/198/489/421198489.geojson
+++ b/data/421/198/489/421198489.geojson
@@ -17,10 +17,19 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ceb_x_preferred":[
+        "Maroon Town"
+    ],
     "name:eng_x_preferred":[
         "Maroon Town"
     ],
     "name:nld_x_preferred":[
+        "Maroon Town"
+    ],
+    "name:nno_x_preferred":[
+        "Maroon Town p\u00e5 Jamaica"
+    ],
+    "name:swe_x_preferred":[
         "Maroon Town"
     ],
     "name:und_x_variant":[
@@ -71,7 +80,7 @@
         }
     ],
     "wof:id":421198489,
-    "wof:lastmodified":1566724663,
+    "wof:lastmodified":1690937468,
     "wof:name":"Maroon Town",
     "wof:parent_id":85672573,
     "wof:placetype":"locality",

--- a/data/421/198/491/421198491.geojson
+++ b/data/421/198/491/421198491.geojson
@@ -20,6 +20,9 @@
     "name:cat_x_preferred":[
         "Malvern"
     ],
+    "name:ceb_x_preferred":[
+        "Malvern"
+    ],
     "name:eng_x_preferred":[
         "Malvern"
     ],
@@ -30,6 +33,9 @@
         "Malvern"
     ],
     "name:spa_x_preferred":[
+        "Malvern"
+    ],
+    "name:swe_x_preferred":[
         "Malvern"
     ],
     "qs:gn_country":"JM",
@@ -77,7 +83,7 @@
         }
     ],
     "wof:id":421198491,
-    "wof:lastmodified":1566724663,
+    "wof:lastmodified":1690937467,
     "wof:name":"Malvern",
     "wof:parent_id":85672569,
     "wof:placetype":"locality",

--- a/data/421/201/315/421201315.geojson
+++ b/data/421/201/315/421201315.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Stony Hill"
+    ],
     "name:ceb_x_preferred":[
         "Stony Hill"
     ],
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":421201315,
-    "wof:lastmodified":1566724664,
+    "wof:lastmodified":1690937469,
     "wof:name":"Stony Hill",
     "wof:parent_id":85672609,
     "wof:placetype":"locality",

--- a/data/421/201/751/421201751.geojson
+++ b/data/421/201/751/421201751.geojson
@@ -20,6 +20,9 @@
     "name:ben_x_preferred":[
         "\u0995\u09c7\u09ae\u09ac\u09cd\u09b0\u09bf\u099c"
     ],
+    "name:ceb_x_preferred":[
+        "Cambridge"
+    ],
     "name:ell_x_preferred":[
         "\u039a\u03ad\u03b9\u03bc\u03c0\u03c1\u03b9\u03c4\u03b6"
     ],
@@ -36,6 +39,9 @@
         "\ucf00\uc784\ube0c\ub9ac\uc9c0"
     ],
     "name:nld_x_preferred":[
+        "Cambridge"
+    ],
+    "name:swe_x_preferred":[
         "Cambridge"
     ],
     "name:tur_x_preferred":[
@@ -100,7 +106,7 @@
         }
     ],
     "wof:id":421201751,
-    "wof:lastmodified":1636495995,
+    "wof:lastmodified":1690937470,
     "wof:name":"Cambridge",
     "wof:parent_id":85672573,
     "wof:placetype":"locality",

--- a/data/421/201/753/421201753.geojson
+++ b/data/421/201/753/421201753.geojson
@@ -20,6 +20,9 @@
     "name:ben_x_preferred":[
         "\u0987\u09b8\u09b2\u09bf\u0982\u0997\u099f\u09a8"
     ],
+    "name:ceb_x_preferred":[
+        "Islington"
+    ],
     "name:eng_x_preferred":[
         "Islington"
     ],
@@ -27,6 +30,9 @@
         "Islington"
     ],
     "name:nld_x_preferred":[
+        "Islington"
+    ],
+    "name:swe_x_preferred":[
         "Islington"
     ],
     "name:tur_x_preferred":[
@@ -76,7 +82,7 @@
         }
     ],
     "wof:id":421201753,
-    "wof:lastmodified":1636495994,
+    "wof:lastmodified":1690937469,
     "wof:name":"Islington",
     "wof:parent_id":85672605,
     "wof:placetype":"locality",

--- a/data/421/201/757/421201757.geojson
+++ b/data/421/201/757/421201757.geojson
@@ -20,6 +20,9 @@
     "name:bul_x_preferred":[
         "\u041c\u043e\u043d\u0435\u0430\u0433\u0443\u0435"
     ],
+    "name:cat_x_preferred":[
+        "Moneague"
+    ],
     "name:ceb_x_preferred":[
         "Moneague"
     ],
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":421201757,
-    "wof:lastmodified":1566724664,
+    "wof:lastmodified":1690937470,
     "wof:name":"Moneague",
     "wof:parent_id":85672599,
     "wof:placetype":"locality",

--- a/data/421/201/761/421201761.geojson
+++ b/data/421/201/761/421201761.geojson
@@ -17,10 +17,16 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ceb_x_preferred":[
+        "Richmond"
+    ],
     "name:eng_x_preferred":[
         "Richmond"
     ],
     "name:nld_x_preferred":[
+        "Richmond"
+    ],
+    "name:swe_x_preferred":[
         "Richmond"
     ],
     "name:und_x_variant":[
@@ -82,7 +88,7 @@
         }
     ],
     "wof:id":421201761,
-    "wof:lastmodified":1636495995,
+    "wof:lastmodified":1690937470,
     "wof:name":"Richmond",
     "wof:parent_id":85672605,
     "wof:placetype":"locality",

--- a/data/421/202/425/421202425.geojson
+++ b/data/421/202/425/421202425.geojson
@@ -20,6 +20,9 @@
     "name:deu_x_preferred":[
         "Belmont - Whitehouse"
     ],
+    "name:ell_x_preferred":[
+        "\u039f\u03c5\u03ac\u03b9\u03c4 \u03a7\u03ac\u03bf\u03c5\u03b6"
+    ],
     "name:eng_x_preferred":[
         "Whitehouse"
     ],
@@ -28,6 +31,9 @@
     ],
     "name:nld_x_preferred":[
         "Whitehouse"
+    ],
+    "name:pol_x_preferred":[
+        "White House"
     ],
     "qs:gn_country":"JM",
     "qs:gn_fcode":"PPL",
@@ -74,7 +80,7 @@
         }
     ],
     "wof:id":421202425,
-    "wof:lastmodified":1566724662,
+    "wof:lastmodified":1690937465,
     "wof:name":"Whitehouse",
     "wof:parent_id":85672583,
     "wof:placetype":"locality",

--- a/data/421/202/975/421202975.geojson
+++ b/data/421/202/975/421202975.geojson
@@ -62,6 +62,9 @@
     "name:nld_x_preferred":[
         "Port Morant"
     ],
+    "name:pol_x_preferred":[
+        "Port Morant"
+    ],
     "name:por_x_preferred":[
         "Port Morant"
     ],
@@ -232,7 +235,7 @@
         }
     ],
     "wof:id":421202975,
-    "wof:lastmodified":1636495993,
+    "wof:lastmodified":1690937465,
     "wof:name":"Port Morant",
     "wof:parent_id":85672615,
     "wof:placetype":"locality",

--- a/data/421/203/989/421203989.geojson
+++ b/data/421/203/989/421203989.geojson
@@ -17,10 +17,16 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ceb_x_preferred":[
+        "Ulster Spring"
+    ],
     "name:eng_x_preferred":[
         "Ulster Spring"
     ],
     "name:nld_x_preferred":[
+        "Ulster Spring"
+    ],
+    "name:swe_x_preferred":[
         "Ulster Spring"
     ],
     "qs:gn_country":"JM",
@@ -68,7 +74,7 @@
         }
     ],
     "wof:id":421203989,
-    "wof:lastmodified":1566724662,
+    "wof:lastmodified":1690937464,
     "wof:name":"Ulster Spring",
     "wof:parent_id":85672579,
     "wof:placetype":"locality",

--- a/data/421/204/655/421204655.geojson
+++ b/data/421/204/655/421204655.geojson
@@ -17,10 +17,16 @@
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ceb_x_preferred":[
+        "Gordon Town"
+    ],
     "name:eng_x_preferred":[
         "Gordon Town"
     ],
     "name:nld_x_preferred":[
+        "Gordon Town"
+    ],
+    "name:swe_x_preferred":[
         "Gordon Town"
     ],
     "qs:gn_country":"JM",
@@ -68,7 +74,7 @@
         }
     ],
     "wof:id":421204655,
-    "wof:lastmodified":1566724661,
+    "wof:lastmodified":1690937464,
     "wof:name":"Gordon Town",
     "wof:parent_id":85672609,
     "wof:placetype":"locality",

--- a/data/856/322/15/85632215.geojson
+++ b/data/856/322/15/85632215.geojson
@@ -29,6 +29,9 @@
     "mz:is_current":1,
     "mz:max_zoom":9.0,
     "mz:min_zoom":4.0,
+    "name:abk_x_preferred":[
+        "\u0418\u0430\u043c\u0430\u0438\u043a\u0430"
+    ],
     "name:ace_x_preferred":[
         "Jamaika"
     ],
@@ -38,14 +41,23 @@
     "name:aka_x_preferred":[
         "Gyameka"
     ],
+    "name:aka_x_variant":[
+        "Jamaica"
+    ],
     "name:als_x_preferred":[
         "Jamaika"
     ],
     "name:amh_x_preferred":[
         "\u1303\u121b\u12ed\u12ab"
     ],
+    "name:ami_x_preferred":[
+        "Jamaica"
+    ],
     "name:ang_x_preferred":[
         "Iamaica"
+    ],
+    "name:anp_x_preferred":[
+        "\u091c\u092e\u0948\u0915\u093e"
     ],
     "name:ara_x_preferred":[
         "\u062c\u0627\u0645\u0627\u064a\u0643\u0627"
@@ -83,11 +95,17 @@
     "name:bam_x_variant":[
         "Zamayiki"
     ],
+    "name:ban_x_preferred":[
+        "Jamaika"
+    ],
     "name:bar_x_preferred":[
         "Jamaika"
     ],
     "name:bcl_x_preferred":[
         "Yamaika"
+    ],
+    "name:bcl_x_variant":[
+        "Hamayka"
     ],
     "name:bel_x_preferred":[
         "\u042f\u043c\u0430\u0439\u043a\u0430"
@@ -101,6 +119,9 @@
     ],
     "name:bho_x_preferred":[
         "\u091c\u092e\u0948\u0915\u093e"
+    ],
+    "name:bis_x_preferred":[
+        "Jamaika"
     ],
     "name:bod_x_preferred":[
         "\u0f47\u0f0b\u0f58\u0f60\u0f72\u0f0b\u0f40"
@@ -132,11 +153,17 @@
     "name:ceb_x_preferred":[
         "Jamaica"
     ],
+    "name:ceb_x_variant":[
+        "Hamayka"
+    ],
     "name:ces_x_preferred":[
         "Jamajka"
     ],
     "name:che_x_preferred":[
         "\u042f\u043c\u0430\u0439\u043a\u0430"
+    ],
+    "name:chr_x_preferred":[
+        "\u13e3\u13ba\u13a2\u13a7"
     ],
     "name:chv_x_preferred":[
         "\u042f\u043c\u0430\u0439\u043a\u0430"
@@ -150,10 +177,16 @@
     "name:cos_x_preferred":[
         "Giamaica"
     ],
+    "name:cps_x_preferred":[
+        "Hamayka"
+    ],
     "name:crh_x_preferred":[
         "Camayka"
     ],
     "name:cym_x_preferred":[
+        "Jamaica"
+    ],
+    "name:dag_x_preferred":[
         "Jamaica"
     ],
     "name:dan_x_preferred":[
@@ -286,6 +319,9 @@
     "name:gom_x_preferred":[
         "\u091c\u092e\u0948\u0915\u093e"
     ],
+    "name:gpe_x_preferred":[
+        "Jamaica"
+    ],
     "name:grn_x_preferred":[
         "Ham\u00e1ika"
     ],
@@ -347,6 +383,9 @@
     "name:hyw_x_preferred":[
         "\u053a\u0561\u0574\u0561\u0575\u0584\u0561"
     ],
+    "name:hyw_x_variant":[
+        "\u0543\u0561\u0574\u0561\u0575\u0584\u0561"
+    ],
     "name:ibo_x_preferred":[
         "Jamaik\u1ea1"
     ],
@@ -386,6 +425,9 @@
     "name:kaa_x_preferred":[
         "Yamaika"
     ],
+    "name:kab_x_preferred":[
+        "\u01e6amayka"
+    ],
     "name:kal_x_preferred":[
         "Jamaica"
     ],
@@ -407,6 +449,9 @@
     "name:kbp_x_preferred":[
         "Camayiki"
     ],
+    "name:kcg_x_preferred":[
+        "Ja\u0331ma\u0331ika"
+    ],
     "name:khm_x_preferred":[
         "\u17a0\u17d2\u179f\u17b6\u1798\u17c9\u17b6\u17a2\u17c9\u17b7\u1782"
     ],
@@ -427,6 +472,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc790\uba54\uc774\uce74"
+    ],
+    "name:krj_x_preferred":[
+        "Hamayka"
     ],
     "name:kur_x_preferred":[
         "Jama\u00eeka"
@@ -468,6 +516,9 @@
     "name:lit_x_preferred":[
         "Jamaika"
     ],
+    "name:lld_x_preferred":[
+        "Giamaica"
+    ],
     "name:lmo_x_preferred":[
         "Giamaica"
     ],
@@ -486,14 +537,23 @@
     "name:lzh_x_preferred":[
         "\u7259\u8cb7\u52a0"
     ],
+    "name:mad_x_preferred":[
+        "Jamaika"
+    ],
     "name:mal_x_preferred":[
         "\u0d1c\u0d2e\u0d48\u0d15\u0d4d\u0d15"
     ],
     "name:mar_x_preferred":[
         "\u091c\u092e\u0948\u0915\u093e"
     ],
+    "name:mdf_x_preferred":[
+        "\u042f\u043c\u0430\u0439\u043a\u0430"
+    ],
     "name:mhr_x_preferred":[
         "\u042f\u043c\u0430\u0439\u043a\u0435"
+    ],
+    "name:min_x_preferred":[
+        "Jamaika"
     ],
     "name:mkd_x_preferred":[
         "\u0408\u0430\u043c\u0430\u0458\u043a\u0430"
@@ -506,6 +566,9 @@
     ],
     "name:mlt_x_preferred":[
         "\u0120amajka"
+    ],
+    "name:mni_x_preferred":[
+        "\uabd6\uabc3\uabe5\uabe2\uabc0\uabe5"
     ],
     "name:mon_x_preferred":[
         "\u042f\u043c\u0430\u0439\u043a"
@@ -597,8 +660,14 @@
     "name:oss_x_preferred":[
         "\u042f\u043c\u0430\u0439\u043a\u00e6"
     ],
+    "name:pag_x_preferred":[
+        "Hamayka"
+    ],
     "name:pam_x_preferred":[
         "Jamaica"
+    ],
+    "name:pam_x_variant":[
+        "Ham\u00e1ika"
     ],
     "name:pan_x_preferred":[
         "\u0a1c\u0a2e\u0a48\u0a15\u0a3e"
@@ -681,6 +750,9 @@
     "name:sgs_x_preferred":[
         "Jamaika"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1075\u103b\u1083\u1087\u1019\u1031\u1087\u1075\u1083\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0da2\u0dd0\u0db8\u0dd9\u0dba\u0dd2\u0d9a\u0dcf\u0dc0"
     ],
@@ -693,8 +765,14 @@
     "name:sme_x_preferred":[
         "Jamaica"
     ],
+    "name:smn_x_preferred":[
+        "Jamaika"
+    ],
     "name:smo_x_preferred":[
         "Jamaica"
+    ],
+    "name:sms_x_preferred":[
+        "Jamaika"
     ],
     "name:sna_x_preferred":[
         "Jamaica"
@@ -760,6 +838,9 @@
     "name:tat_x_preferred":[
         "\u042f\u043c\u0430\u0439\u043a\u0430"
     ],
+    "name:tay_x_preferred":[
+        "Jamaica"
+    ],
     "name:tel_x_preferred":[
         "\u0c1c\u0c2e\u0c48\u0c15\u0c3e"
     ],
@@ -784,8 +865,14 @@
     "name:tir_x_preferred":[
         "\u1303\u121b\u12ed\u12ab"
     ],
+    "name:tok_x_preferred":[
+        "ma Sameka"
+    ],
     "name:ton_x_preferred":[
         "Samaika"
+    ],
+    "name:trv_x_preferred":[
+        "Jamaica"
     ],
     "name:tuk_x_preferred":[
         "\u00ddama\u00fdka"
@@ -814,6 +901,9 @@
     "name:vec_x_preferred":[
         "Giamaica"
     ],
+    "name:vec_x_variant":[
+        "Zam\u00e0ega"
+    ],
     "name:vep_x_preferred":[
         "Jamaik"
     ],
@@ -831,6 +921,9 @@
     ],
     "name:war_x_preferred":[
         "Jamaica"
+    ],
+    "name:war_x_variant":[
+        "Hamayka"
     ],
     "name:wol_x_preferred":[
         "Jamayka"
@@ -894,6 +987,9 @@
     ],
     "name:zul_x_preferred":[
         "i-Jamaica"
+    ],
+    "name:zul_x_variant":[
+        "I-Jamaica"
     ],
     "ne:abbrev":"Jam.",
     "ne:abbrev_len":4,
@@ -1112,7 +1208,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1617827417,
+    "wof:lastmodified":1690937459,
     "wof:name":"Jamaica",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/725/59/85672559.geojson
+++ b/data/856/725/59/85672559.geojson
@@ -70,8 +70,17 @@
     "name:fra_x_variant":[
         "Clarendon"
     ],
+    "name:frr_x_preferred":[
+        "Clarendon"
+    ],
+    "name:gle_x_preferred":[
+        "Par\u00f3iste Clarendon"
+    ],
     "name:guj_x_preferred":[
         "\u0a95\u0acd\u0ab2\u0ac7\u0ab0\u0ac7\u0aa8\u0acd\u0aa1\u0aa8 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
+    ],
+    "name:heb_x_preferred":[
+        "\u05de\u05d7\u05d5\u05d6 \u05e7\u05dc\u05e8\u05e0\u05d3\u05d5\u05df"
     ],
     "name:hin_x_preferred":[
         "\u0915\u094d\u0932\u0948\u0930\u0947\u0902\u0921\u094b\u0928 \u092a\u0948\u0930\u093f\u0936"
@@ -97,6 +106,9 @@
     "name:kor_x_preferred":[
         "\ud074\ub798\ub7f0\ub358 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ud074\ub798\ub7f0\ub358\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Klarendonas pagasts"
     ],
@@ -118,6 +130,9 @@
     "name:nob_x_preferred":[
         "Clarendon prestegjeld"
     ],
+    "name:nob_x_variant":[
+        "Clarendon Parish"
+    ],
     "name:nor_x_preferred":[
         "Clarendon prestegjeld"
     ],
@@ -129,6 +144,9 @@
     ],
     "name:rus_x_preferred":[
         "\u041a\u043b\u0430\u0440\u0435\u043d\u0434\u043e\u043d"
+    ],
+    "name:sco_x_preferred":[
+        "Clarendon Pairish"
     ],
     "name:sin_x_preferred":[
         "\u0d9a\u0dca\u0dbd\u0dbb\u0dd9\u0db1\u0dca\u0da9\u0db1\u0dca \u0db4\u0dca\u200d\u0dbb\u0dcf\u0db1\u0dca\u0dad\u0dba"
@@ -293,7 +311,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495980,
+    "wof:lastmodified":1690937455,
     "wof:name":"Clarendon",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/63/85672563.geojson
+++ b/data/856/725/63/85672563.geojson
@@ -79,6 +79,9 @@
     "name:fra_x_variant":[
         "Hanover"
     ],
+    "name:frr_x_preferred":[
+        "Hanover"
+    ],
     "name:guj_x_preferred":[
         "\u0ab9\u0ac7\u0aa8\u0acb\u0ab5\u0ab0 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -109,6 +112,9 @@
     "name:kor_x_preferred":[
         "\ud574\ub178\ubc84 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ud574\ub178\ubc84\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Henoveras pagasts"
     ],
@@ -130,6 +136,9 @@
     "name:nob_x_preferred":[
         "Hanover prestegjeld"
     ],
+    "name:nob_x_variant":[
+        "Hanover Parish"
+    ],
     "name:pol_x_preferred":[
         "Hanover"
     ],
@@ -138,6 +147,9 @@
     ],
     "name:rus_x_preferred":[
         "\u041f\u0440\u0438\u0445\u043e\u0434 \u0413\u0430\u043d\u043d\u043e\u0432\u0435\u0440"
+    ],
+    "name:rus_x_variant":[
+        "\u0425\u0430\u043d\u043e\u0432\u0435\u0440"
     ],
     "name:sin_x_preferred":[
         "\u0dc4\u0dd0\u0db1\u0ddd\u0dc0\u0dbb\u0dca \u0db4\u0dca\u200d\u0dbb\u0dcf\u0db1\u0dca\u0dad\u0dba"
@@ -301,7 +313,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495982,
+    "wof:lastmodified":1690937458,
     "wof:name":"Hanover",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/67/85672567.geojson
+++ b/data/856/725/67/85672567.geojson
@@ -58,6 +58,9 @@
     "name:eus_x_preferred":[
         "Manchester"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0631\u06cc\u0634 \u0645\u0646\u0686\u0633\u062a\u0631"
+    ],
     "name:fin_x_preferred":[
         "Manchesterin kunta"
     ],
@@ -65,6 +68,9 @@
         "Paroisse de Manchester"
     ],
     "name:fra_x_variant":[
+        "Manchester"
+    ],
+    "name:frr_x_preferred":[
         "Manchester"
     ],
     "name:guj_x_preferred":[
@@ -97,6 +103,9 @@
     "name:kor_x_preferred":[
         "\ub9e8\uccb4\uc2a4\ud130 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ub9e8\uccb4\uc2a4\ud130\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Man\u010destras pagasts"
     ],
@@ -117,6 +126,9 @@
     ],
     "name:nob_x_preferred":[
         "Manchester prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Manchester Parish"
     ],
     "name:pol_x_preferred":[
         "Manchester"
@@ -289,7 +301,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495981,
+    "wof:lastmodified":1690937456,
     "wof:name":"Manchester",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/69/85672569.geojson
+++ b/data/856/725/69/85672569.geojson
@@ -78,6 +78,9 @@
     "name:fra_x_variant":[
         "Saint Elizabeth"
     ],
+    "name:frr_x_preferred":[
+        "Saint Elizabeth"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0a8f\u0ab2\u0abf\u0a9d\u0abe\u0aac\u0ac7\u0aa5 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -108,6 +111,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uc5d8\ub9ac\uc790\ubca0\uc2a4 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uc5d8\ub9ac\uc790\ubca0\uc2a4\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Senelizabetes pagasts"
     ],
@@ -128,6 +134,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint Elizabeth prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Elizabeth Parish"
     ],
     "name:nor_x_preferred":[
         "Saint Elizabeth prestegjeld"
@@ -301,7 +310,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495980,
+    "wof:lastmodified":1690937455,
     "wof:name":"Saint Elizabeth",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/73/85672573.geojson
+++ b/data/856/725/73/85672573.geojson
@@ -37,8 +37,17 @@
     "name:ara_x_variant":[
         "\u0623\u0628\u0631\u0634\u064a\u0629 \u0633\u0627\u0646\u062a \u062c\u064a\u0645\u0633"
     ],
+    "name:bel_x_preferred":[
+        "\u043f\u0440\u044b\u0445\u043e\u0434 \u0421\u0435\u043d\u0442-\u0414\u0436\u044d\u0439\u043c\u0441"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u0987\u09a8\u09cd\u099f \u099c\u09c7\u09ae\u09b8 \u09aa\u09be\u09b0\u09bf\u09b6"
+    ],
+    "name:bre_x_preferred":[
+        "Saint James Parish"
+    ],
+    "name:cat_x_preferred":[
+        "Saint James"
     ],
     "name:ceb_x_preferred":[
         "Parish of Saint James"
@@ -69,6 +78,9 @@
     "name:eus_x_preferred":[
         "Saint James"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0627\u0631\u06cc\u0633 \u0633\u0646\u062a \u062c\u06cc\u0645\u0632"
+    ],
     "name:fin_x_preferred":[
         "Saint Jamesin pit\u00e4j\u00e4"
     ],
@@ -77,6 +89,12 @@
     ],
     "name:fra_x_variant":[
         "Saint James"
+    ],
+    "name:frr_x_preferred":[
+        "Saint James"
+    ],
+    "name:gle_x_preferred":[
+        "Par\u00f3iste Saint James"
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0a82\u0a9f \u0a9c\u0ac7\u0aae\u0acd\u0ab8 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
@@ -108,6 +126,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uc81c\uc784\uc2a4 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uc81c\uc784\uc2a4\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Send\u017eeimsa pagasts"
     ],
@@ -128,6 +149,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint James prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint James Parish"
     ],
     "name:nor_x_preferred":[
         "Saint James prestegjeld"
@@ -176,6 +200,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8056\u8a79\u59c6\u65af\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u5723\u8a79\u59c6\u65af\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"JAM",
@@ -301,7 +328,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495981,
+    "wof:lastmodified":1690937456,
     "wof:name":"Saint James",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/79/85672579.geojson
+++ b/data/856/725/79/85672579.geojson
@@ -76,6 +76,12 @@
     "name:fra_x_variant":[
         "Trelawny"
     ],
+    "name:frr_x_preferred":[
+        "Trelawny"
+    ],
+    "name:gle_x_preferred":[
+        "Par\u00f3iste Trelawny"
+    ],
     "name:guj_x_preferred":[
         "\u0a9f\u0acd\u0ab0\u0ac7\u0ab2\u0ac7\u0ab5\u0acd\u0aa8\u0ac0 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -109,6 +115,9 @@
     "name:kor_x_preferred":[
         "\ud2b8\ub810\ub85c\ub2c8 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ud2b8\ub810\ub85c\ub2c8\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Triloni pagasts"
     ],
@@ -129,6 +138,9 @@
     ],
     "name:nob_x_preferred":[
         "Trelawny prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Trelawny Parish"
     ],
     "name:oci_x_preferred":[
         "Parr\u00f2quia de Trelawny"
@@ -304,7 +316,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495982,
+    "wof:lastmodified":1690937458,
     "wof:name":"Trelawny",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/83/85672583.geojson
+++ b/data/856/725/83/85672583.geojson
@@ -46,6 +46,9 @@
     "name:ell_x_preferred":[
         "\u0393\u03bf\u03c5\u03b5\u03c3\u03c4\u03bc\u03cc\u03c1\u03bb\u03b1\u03bd\u03c4"
     ],
+    "name:ell_x_variant":[
+        "\u039f\u03c5\u03b5\u03c3\u03c4\u03bc\u03cc\u03c1\u03bb\u03b1\u03bd\u03c4"
+    ],
     "name:eng_x_preferred":[
         "Westmoreland"
     ],
@@ -62,6 +65,9 @@
         "Paroisse de Westmoreland"
     ],
     "name:fra_x_variant":[
+        "Westmoreland"
+    ],
+    "name:frr_x_preferred":[
         "Westmoreland"
     ],
     "name:guj_x_preferred":[
@@ -94,6 +100,9 @@
     "name:kor_x_preferred":[
         "\uc6e8\uc2a4\ud2b8\ubaa8\uc5bc\ub79c\ub4dc \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc6e8\uc2a4\ud2b8\ubaa8\uc5bc\ub79c\ub4dc\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Vestmorlendas pagasts"
     ],
@@ -114,6 +123,9 @@
     ],
     "name:nob_x_preferred":[
         "Westmoreland prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Westmoreland Parish"
     ],
     "name:nor_x_preferred":[
         "Westmoreland prestegjeld"
@@ -293,7 +305,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495982,
+    "wof:lastmodified":1690937459,
     "wof:name":"Westmoreland",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/87/85672587.geojson
+++ b/data/856/725/87/85672587.geojson
@@ -73,6 +73,9 @@
     "name:eus_x_preferred":[
         "Kingston Parish"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0631\u06cc\u0634 \u06a9\u06cc\u0646\u06af\u0633\u062a\u0648\u0646"
+    ],
     "name:fin_x_preferred":[
         "Kingston"
     ],
@@ -83,6 +86,9 @@
         "Paroisse de Kingston"
     ],
     "name:fra_x_variant":[
+        "Kingston"
+    ],
+    "name:frr_x_preferred":[
         "Kingston"
     ],
     "name:guj_x_preferred":[
@@ -121,6 +127,9 @@
     "name:kor_x_preferred":[
         "\ud0b9\uc2a4\ud134 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ud0b9\uc2a4\ud134\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Kingstonas pagasts"
     ],
@@ -147,6 +156,9 @@
     ],
     "name:nob_x_preferred":[
         "Kingston prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Kingston Parish"
     ],
     "name:nor_x_preferred":[
         "Kingston prestegjeld"
@@ -337,7 +349,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495981,
+    "wof:lastmodified":1690937456,
     "wof:name":"Kingston",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/91/85672591.geojson
+++ b/data/856/725/91/85672591.geojson
@@ -55,6 +55,9 @@
     "name:eus_x_preferred":[
         "Portland"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0648\u0631\u062a\u0644\u0646\u062f \u067e\u0631\u06cc\u0634"
+    ],
     "name:fin_x_preferred":[
         "Portlandin kunta"
     ],
@@ -62,6 +65,9 @@
         "Paroisse de Portland"
     ],
     "name:fra_x_variant":[
+        "Portland"
+    ],
+    "name:frr_x_preferred":[
         "Portland"
     ],
     "name:guj_x_preferred":[
@@ -91,6 +97,9 @@
     "name:kor_x_preferred":[
         "\ud3ec\ud2c0\ub79c\ub4dc \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\ud3ec\ud2c0\ub79c\ub4dc\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Portlendas pagasts"
     ],
@@ -111,6 +120,9 @@
     ],
     "name:nob_x_preferred":[
         "Portland prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Portland Parish"
     ],
     "name:pol_x_preferred":[
         "Portland"
@@ -280,7 +292,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495981,
+    "wof:lastmodified":1690937457,
     "wof:name":"Portland",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/99/85672599.geojson
+++ b/data/856/725/99/85672599.geojson
@@ -40,6 +40,9 @@
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u09a8\u09cd\u099f \u0985\u09cd\u09af\u09be\u09a8 \u09aa\u09be\u09b0\u09bf\u09b6"
     ],
+    "name:cat_x_preferred":[
+        "Saint Ann"
+    ],
     "name:ceb_x_preferred":[
         "Parish of Saint Ann"
     ],
@@ -78,6 +81,12 @@
     "name:fra_x_variant":[
         "Saint Ann"
     ],
+    "name:frr_x_preferred":[
+        "Saint Ann"
+    ],
+    "name:gle_x_preferred":[
+        "Par\u00f3iste Saint Ann"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0a8f\u0aa8 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -89,6 +98,9 @@
     ],
     "name:hun_x_preferred":[
         "Saint Ann"
+    ],
+    "name:hye_x_preferred":[
+        "\u054d\u0565\u0576\u0569 \u0537\u0576 \u0577\u0580\u057b\u0561\u0576"
     ],
     "name:ind_x_preferred":[
         "Paroki Saint Ann"
@@ -107,6 +119,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uc564 \uad50\uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uc564\uad6c"
     ],
     "name:lav_x_preferred":[
         "Sentenas pagasts"
@@ -129,6 +144,9 @@
     "name:nob_x_preferred":[
         "Saint Ann prestegjeld"
     ],
+    "name:nob_x_variant":[
+        "Saint Ann Parish"
+    ],
     "name:pol_x_preferred":[
         "Saint Ann"
     ],
@@ -137,6 +155,9 @@
     ],
     "name:rus_x_preferred":[
         "\u043f\u0440\u0438\u0445\u043e\u0434 \u0421\u0435\u043d\u0442-\u042d\u043d\u043d"
+    ],
+    "name:rus_x_variant":[
+        "\u0421\u0435\u043d\u0442-\u0410\u043d\u043d"
     ],
     "name:scn_x_preferred":[
         "Saint Ann"
@@ -300,7 +321,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495981,
+    "wof:lastmodified":1690937457,
     "wof:name":"Saint Ann",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/726/01/85672601.geojson
+++ b/data/856/726/01/85672601.geojson
@@ -40,6 +40,9 @@
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u09a8\u09cd\u099f \u0995\u09cd\u09af\u09be\u09a5\u09c7\u09b0\u09bf\u09a8 \u09aa\u09cd\u09af\u09be\u09b0\u09bf\u09b6"
     ],
+    "name:cat_x_preferred":[
+        "Saint Catherine"
+    ],
     "name:ceb_x_preferred":[
         "Parish of Saint Catherine"
     ],
@@ -78,6 +81,9 @@
     "name:fra_x_variant":[
         "Sainte-Catherine"
     ],
+    "name:frr_x_preferred":[
+        "Saint Catherine"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0a95\u0ac7\u0aa5\u0ab0\u0abf\u0aa8 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -108,6 +114,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uce90\uc11c\ub9b0 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uce90\uc11c\ub9b0\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentketerinas pagasts"
     ],
@@ -128,6 +137,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint Catherine prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Catherine Parish"
     ],
     "name:nor_x_preferred":[
         "Saint Catherine prestegjeld"
@@ -153,6 +165,9 @@
     "name:swe_x_preferred":[
         "Parish of Saint Catherine"
     ],
+    "name:swe_x_variant":[
+        "Saint Catherine Parish"
+    ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bc6\u0baf\u0bbf\u0ba9\u0bcd\u0b9f\u0bcd \u0b95\u0bc7\u0ba4\u0bcd\u0ba4\u0bb0\u0bbf\u0ba9\u0bcd \u0baa\u0bb0\u0bbf\u0bb7\u0bcd"
     ],
@@ -167,6 +182,9 @@
     ],
     "name:ukr_x_preferred":[
         "\u0421\u0435\u043d\u0442-\u041a\u0435\u0442\u0440\u0456\u043d"
+    ],
+    "name:ukr_x_variant":[
+        "\u0421\u0435\u043d\u0442-\u041a\u0435\u0442\u0435\u0440\u0438\u043d"
     ],
     "name:urd_x_preferred":[
         "\u0633\u06cc\u0646\u0679 \u06a9\u06cc\u062a\u06be\u0631\u06cc\u0646 \u067e\u06cc\u0631\u0634"
@@ -301,7 +319,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495983,
+    "wof:lastmodified":1690937460,
     "wof:name":"Saint Catherine",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/726/05/85672605.geojson
+++ b/data/856/726/05/85672605.geojson
@@ -37,6 +37,9 @@
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u09a8\u09cd\u099f \u09ae\u09c7\u09b0\u09bf \u09aa\u09cd\u09af\u09be\u09b0\u09bf\u09b6"
     ],
+    "name:cat_x_preferred":[
+        "Saint Mary"
+    ],
     "name:ceb_x_preferred":[
         "Parish of Saint Mary"
     ],
@@ -76,6 +79,9 @@
         "paroisse de Saint Mary",
         "Saint Mary"
     ],
+    "name:frr_x_preferred":[
+        "Saint Mary"
+    ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0aa8\u0acd\u0a9f \u0aae\u0ac7\u0ab0\u0ac0 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
     ],
@@ -106,6 +112,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uba54\ub9ac \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uba54\ub9ac\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentmer\u012b pagasts"
     ],
@@ -123,6 +132,9 @@
     ],
     "name:nob_x_preferred":[
         "Saint Mary prestegjeld"
+    ],
+    "name:nob_x_variant":[
+        "Saint Mary Parish"
     ],
     "name:nor_x_preferred":[
         "Saint Mary prestegjeld"
@@ -299,7 +311,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495983,
+    "wof:lastmodified":1690937460,
     "wof:name":"Saint Mary",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/726/09/85672609.geojson
+++ b/data/856/726/09/85672609.geojson
@@ -37,6 +37,9 @@
     "name:ben_x_preferred":[
         "\u09b8\u09c7\u09a8\u09cd\u099f \u0985\u09cd\u09af\u09be\u09a8\u09cd\u09a1\u09cd\u09b0\u09c1"
     ],
+    "name:cat_x_preferred":[
+        "Saint Andrew"
+    ],
     "name:cym_x_preferred":[
         "Saint Andrew"
     ],
@@ -47,20 +50,28 @@
         "Saint Andrew Parish"
     ],
     "name:deu_x_variant":[
-        "Saint Andrew"
+        "Saint Andrew",
+        "Kreis Saint Andrew"
     ],
     "name:ell_x_preferred":[
         "\u0386\u03b3\u03b9\u03bf\u03c2 \u0391\u03bd\u03b4\u03c1\u03ad\u03b1\u03c2"
+    ],
+    "name:ell_x_variant":[
+        "\u03a3\u03b1\u03b9\u03bd\u03c4 \u0386\u03bd\u03c4\u03c1\u03b9\u03bf\u03c5"
     ],
     "name:eng_x_preferred":[
         "Saint Andrew"
     ],
     "name:eng_x_variant":[
         "St Andrew",
-        "St. Andrew"
+        "St. Andrew",
+        "Saint Andrew Parish"
     ],
     "name:eus_x_preferred":[
         "Saint Andrew"
+    ],
+    "name:fas_x_preferred":[
+        "\u067e\u0631\u06cc\u0634 \u0633\u0646\u062a \u0627\u0646\u062f\u0631\u0648"
     ],
     "name:fin_x_preferred":[
         "Saint Andrew"
@@ -69,6 +80,9 @@
         "Paroisse de Saint Andrew"
     ],
     "name:fra_x_variant":[
+        "Saint Andrew"
+    ],
+    "name:frr_x_preferred":[
         "Saint Andrew"
     ],
     "name:guj_x_preferred":[
@@ -99,9 +113,15 @@
     "name:kan_x_preferred":[
         "\u0cb8\u0cc7\u0c82\u0c9f\u0ccd \u0c86\u0c82\u0ca1\u0ccd\u0cb0\u0ccd\u0caf\u0cc2"
     ],
+    "name:kat_x_preferred":[
+        "\u10e1\u10d4\u10dc\u10e2-\u10d4\u10dc\u10d3\u10e0\u10d8\u10e3"
+    ],
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\uc564\ub4dc\ub958",
         "\uc138\uc778\ud2b8\uc564\ub4dc\ub8e8 \uad50\uad6c"
+    ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\uc564\ub4dc\ub8e8\uad6c"
     ],
     "name:lav_x_preferred":[
         "Senendrj\u016b pagasts"
@@ -124,6 +144,9 @@
     "name:nob_x_preferred":[
         "Saint Andrew prestegjeld"
     ],
+    "name:nob_x_variant":[
+        "Saint Andrew Parish"
+    ],
     "name:nor_x_preferred":[
         "Saint Andrew prestegjeld"
     ],
@@ -138,6 +161,9 @@
     ],
     "name:rus_x_variant":[
         "\u041f\u0440\u0438\u0445\u043e\u0434 \u0421\u0435\u043d\u0442-\u0410\u043d\u0434\u0440\u0443"
+    ],
+    "name:sco_x_preferred":[
+        "Saint Andrew Pairish"
     ],
     "name:sin_x_preferred":[
         "\u0dc1\u0dcf\u0db1\u0dca\u0dad \u0d87\u0db1\u0dca\u0da9\u0dd8"
@@ -308,7 +334,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495983,
+    "wof:lastmodified":1690937460,
     "wof:name":"Saint Andrew",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/726/15/85672615.geojson
+++ b/data/856/726/15/85672615.geojson
@@ -40,6 +40,9 @@
     "name:bul_x_preferred":[
         "\u0421\u0435\u0439\u043d\u0442 \u0422\u043e\u043c\u0430\u0441"
     ],
+    "name:cat_x_preferred":[
+        "Saint Thomas"
+    ],
     "name:ceb_x_preferred":[
         "Parish of Saint Thomas"
     ],
@@ -63,6 +66,9 @@
     "name:eus_x_preferred":[
         "Saint Thomas"
     ],
+    "name:fas_x_preferred":[
+        "\u067e\u0631\u06cc\u0634 \u0633\u0646\u062a \u062a\u0648\u0645\u0627\u0633"
+    ],
     "name:fin_x_preferred":[
         "Saint Thomasin kunta"
     ],
@@ -71,6 +77,9 @@
     ],
     "name:fra_x_variant":[
         "Saint-Thomas"
+    ],
+    "name:frr_x_preferred":[
+        "Saint Thomas"
     ],
     "name:guj_x_preferred":[
         "\u0ab8\u0ac7\u0a82\u0a9f \u0aa5\u0acb\u0aae\u0ab8 \u0aaa\u0ac5\u0ab0\u0abf\u0ab6"
@@ -99,6 +108,9 @@
     "name:kor_x_preferred":[
         "\uc138\uc778\ud2b8\ud1a0\uba38\uc2a4 \uad50\uad6c"
     ],
+    "name:kor_x_variant":[
+        "\uc138\uc778\ud2b8\ud1a0\uba38\uc2a4\uad6c"
+    ],
     "name:lav_x_preferred":[
         "Sentomasa pagasts"
     ],
@@ -117,6 +129,9 @@
     "name:nob_x_preferred":[
         "Saint Thomas prestegjeld"
     ],
+    "name:nob_x_variant":[
+        "Saint Thomas Parish"
+    ],
     "name:nor_x_preferred":[
         "Saint Thomas prestegjeld"
     ],
@@ -130,7 +145,8 @@
         "\u0421\u044d\u043d\u0442-\u0422\u043e\u043c\u0430\u0441"
     ],
     "name:rus_x_variant":[
-        "\u0421\u0435\u0439\u043d\u0442 \u0422\u043e\u043c\u0430\u0441"
+        "\u0421\u0435\u0439\u043d\u0442 \u0422\u043e\u043c\u0430\u0441",
+        "\u0421\u0435\u043d\u0442-\u0422\u043e\u043c\u0430\u0441"
     ],
     "name:sin_x_preferred":[
         "\u0dc1\u0dcf\u0db1\u0dca\u0dad \u0dad\u0ddd\u0db8\u0dc3\u0dca \u0db4\u0dca\u200d\u0dbb\u0dcf\u0db1\u0dca\u0dad\u0dba"
@@ -143,6 +159,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bc6\u0baf\u0bbf\u0ba9\u0bcd\u0b9f\u0bcd  \u0ba4\u0bbe\u0bae\u0bb8\u0bcd \u0baa\u0bbe\u0bb0\u0bbf\u0bb8\u0bcd"
+    ],
+    "name:tam_x_variant":[
+        "\u0b9a\u0bc6\u0baf\u0bbf\u0ba9\u0bcd\u0b9f\u0bcd \u0ba4\u0bbe\u0bae\u0bb8\u0bcd \u0baa\u0bbe\u0bb0\u0bbf\u0bb8\u0bcd"
     ],
     "name:tel_x_preferred":[
         "\u0c38\u0c46\u0c2f\u0c3f\u0c02\u0c1f\u0c4d \u0c25\u0c3e\u0c2e\u0c38\u0c4d \u0c2a\u0c3e\u0c30\u0c3f\u0c37\u0c4d"
@@ -176,6 +195,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8056\u6258\u99ac\u65af\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u5723\u6258\u9a6c\u65af\u533a"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"JAM",
@@ -301,7 +323,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636495983,
+    "wof:lastmodified":1690937461,
     "wof:name":"Saint Thomas",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/857/938/99/85793899.geojson
+++ b/data/857/938/99/85793899.geojson
@@ -97,6 +97,9 @@
     "name:tur_x_preferred":[
         "Half Way Tree"
     ],
+    "name:ukr_x_preferred":[
+        "\u0425\u0430\u0444-\u0412\u0435\u0439-\u0422\u0440\u0438"
+    ],
     "name:urd_x_preferred":[
         "\u06c1\u0627\u0641 \u0648\u06d2 \u0679\u0631\u06cc"
     ],
@@ -170,7 +173,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1636495980,
+    "wof:lastmodified":1690937454,
     "wof:name":"Half Way Tree",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/939/15/85793915.geojson
+++ b/data/857/939/15/85793915.geojson
@@ -49,11 +49,23 @@
     "name:arg_x_preferred":[
         "Kingston"
     ],
+    "name:ary_x_preferred":[
+        "\u0643\u064a\u0646\u06ad\u0633\u0637\u0648\u0646"
+    ],
+    "name:arz_x_preferred":[
+        "\u0643\u064a\u0646\u062c\u0633\u062a\u0648\u0646"
+    ],
     "name:ast_x_preferred":[
+        "Kingston"
+    ],
+    "name:avk_x_preferred":[
         "Kingston"
     ],
     "name:aze_x_preferred":[
         "Kinqston"
+    ],
+    "name:ban_x_preferred":[
+        "Kingston"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u041a\u0456\u043d\u0433\u0441\u0442\u0430\u043d"
@@ -136,6 +148,9 @@
     "name:fra_x_preferred":[
         "Kingston"
     ],
+    "name:frr_x_preferred":[
+        "Kingston"
+    ],
     "name:fry_x_preferred":[
         "Kingston"
     ],
@@ -162,6 +177,9 @@
     ],
     "name:hat_x_preferred":[
         "Kinst\u00f2n"
+    ],
+    "name:hau_x_preferred":[
+        "Kingston"
     ],
     "name:hbs_x_preferred":[
         "Kingston"
@@ -235,6 +253,9 @@
     "name:kor_x_preferred":[
         "\ud0b9\uc2a4\ud134"
     ],
+    "name:kur_x_preferred":[
+        "Kingston"
+    ],
     "name:lat_x_preferred":[
         "Regiopolis"
     ],
@@ -242,6 +263,9 @@
         "Kingstona"
     ],
     "name:lfn_x_preferred":[
+        "Kingston"
+    ],
+    "name:lij_x_preferred":[
         "Kingston"
     ],
     "name:lit_x_preferred":[
@@ -262,11 +286,17 @@
     "name:mar_x_preferred":[
         "\u0915\u093f\u0902\u0917\u094d\u0938\u094d\u091f\u0928"
     ],
+    "name:mdf_x_preferred":[
+        "\u041a\u0438\u043d\u0433\u0441\u0442\u043e\u043d"
+    ],
     "name:mkd_x_preferred":[
         "\u041a\u0438\u043d\u0433\u0441\u0442\u043e\u043d"
     ],
     "name:mon_x_preferred":[
         "\u041a\u0438\u043d\u0433\u0441\u0442\u043e\u043d"
+    ],
+    "name:mos_x_preferred":[
+        "Kingston"
     ],
     "name:msa_x_preferred":[
         "Kingston"
@@ -325,6 +355,9 @@
     "name:ron_x_preferred":[
         "Kingston"
     ],
+    "name:rue_x_preferred":[
+        "\u041a\u0438\u043d\u0433\u0441\u0442\u043e\u043d"
+    ],
     "name:rus_x_preferred":[
         "\u041a\u0438\u043d\u0433\u0441\u0442\u043e\u043d"
     ],
@@ -344,6 +377,15 @@
         "Kingston"
     ],
     "name:slv_x_preferred":[
+        "Kingston"
+    ],
+    "name:sme_x_preferred":[
+        "Kingston"
+    ],
+    "name:smn_x_preferred":[
+        "Kingston"
+    ],
+    "name:sms_x_preferred":[
         "Kingston"
     ],
     "name:sna_x_preferred":[
@@ -379,6 +421,9 @@
     "name:tel_x_preferred":[
         "\u0c15\u0c3f\u0c02\u0c17\u0c4d\u0c38\u0c4d\u0c1f\u0c28\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u041a\u0438\u043d\u0433\u0441\u0442\u043e\u043d"
+    ],
     "name:tgl_x_preferred":[
         "Kingston"
     ],
@@ -391,6 +436,9 @@
     "name:tur_x_preferred":[
         "Kingston"
     ],
+    "name:udm_x_preferred":[
+        "\u041a\u0438\u043d\u0433\u0441\u0442\u043e\u043d"
+    ],
     "name:ukr_x_preferred":[
         "\u041a\u0456\u043d\u0433\u0441\u0442\u043e\u043d"
     ],
@@ -401,6 +449,9 @@
         "\u06a9\u0646\u06af\u0633\u0679\u0646"
     ],
     "name:uzb_x_preferred":[
+        "Kingston"
+    ],
+    "name:vec_x_preferred":[
         "Kingston"
     ],
     "name:vep_x_preferred":[
@@ -418,6 +469,9 @@
     "name:wln_x_preferred":[
         "Kingston"
     ],
+    "name:wuu_x_preferred":[
+        "\u91d1\u65af\u6566"
+    ],
     "name:xmf_x_preferred":[
         "\u10d9\u10d8\u10dc\u10d2\u10e1\u10e2\u10dd\u10dc\u10d8"
     ],
@@ -432,6 +486,9 @@
     ],
     "name:zho_x_preferred":[
         "\u4eac\u65af\u6566"
+    ],
+    "name:zho_x_variant":[
+        "\u91d1\u65af\u6566"
     ],
     "name:zho_yue_x_preferred":[
         "\u4eac\u58eb\u9813"
@@ -501,7 +558,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1582319498,
+    "wof:lastmodified":1690937455,
     "wof:name":"New Kingston",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/939/23/85793923.geojson
+++ b/data/857/939/23/85793923.geojson
@@ -27,6 +27,12 @@
     "mz:max_zoom":18.0,
     "mz:min_zoom":14.0,
     "mz:tier_locality":1,
+    "name:ast_x_preferred":[
+        "Trenchtown"
+    ],
+    "name:ben_x_preferred":[
+        "\u099f\u09cd\u09b0\u09c7\u099e\u09cd\u099a\u099f\u09be\u0989\u09a8"
+    ],
     "name:deu_x_preferred":[
         "Trenchtown"
     ],
@@ -131,7 +137,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1582319498,
+    "wof:lastmodified":1690937454,
     "wof:name":"Trench Town",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/417/883/890417883.geojson
+++ b/data/890/417/883/890417883.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":11.0,
+    "name:bul_x_preferred":[
+        "\u0421\u0438\u043b\u043e\u0430\u0445"
+    ],
+    "name:ceb_x_preferred":[
+        "Siloah"
+    ],
     "name:eng_x_preferred":[
         "Siloah"
     ],
@@ -26,6 +32,9 @@
         "\u30b7\u30ed\u30a2"
     ],
     "name:nld_x_preferred":[
+        "Siloah"
+    ],
+    "name:swe_x_preferred":[
         "Siloah"
     ],
     "name:und_x_variant":[
@@ -62,7 +71,7 @@
         }
     ],
     "wof:id":890417883,
-    "wof:lastmodified":1566724665,
+    "wof:lastmodified":1690937474,
     "wof:name":"Siloah",
     "wof:parent_id":85672569,
     "wof:placetype":"locality",

--- a/data/890/418/157/890418157.geojson
+++ b/data/890/418/157/890418157.geojson
@@ -19,10 +19,16 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ceb_x_preferred":[
+        "Easington"
+    ],
     "name:eng_x_preferred":[
         "Easington"
     ],
     "name:nld_x_preferred":[
+        "Easington"
+    ],
+    "name:swe_x_preferred":[
         "Easington"
     ],
     "qs:name":"Easington",
@@ -56,7 +62,7 @@
         }
     ],
     "wof:id":890418157,
-    "wof:lastmodified":1566724666,
+    "wof:lastmodified":1690937476,
     "wof:name":"Easington",
     "wof:parent_id":85672615,
     "wof:placetype":"locality",

--- a/data/890/420/429/890420429.geojson
+++ b/data/890/420/429/890420429.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646\u062a\u0627 \u0643\u0631\u0648\u0632"
     ],
+    "name:ast_x_preferred":[
+        "Santa Cruz"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09be\u09a8\u09cd\u09a4\u09be \u0995\u09cd\u09b0\u09c1\u099c"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:fas_x_preferred":[
         "\u0633\u0627\u0646\u062a\u0627 \u06a9\u0631\u0648\u0632"
+    ],
+    "name:fas_x_variant":[
+        "\u0633\u0627\u0646\u062a\u0627\u06a9\u0631\u0648\u0632"
     ],
     "name:fra_x_preferred":[
         "Santa Cruz"
@@ -134,7 +140,7 @@
         }
     ],
     "wof:id":890420429,
-    "wof:lastmodified":1636495995,
+    "wof:lastmodified":1690937476,
     "wof:name":"Santa Cruz",
     "wof:parent_id":85672569,
     "wof:placetype":"locality",

--- a/data/890/429/173/890429173.geojson
+++ b/data/890/429/173/890429173.geojson
@@ -19,13 +19,28 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "Oracabessa"
+    ],
+    "name:ceb_x_preferred":[
+        "Oracabessa"
+    ],
     "name:eng_x_preferred":[
+        "Oracabessa"
+    ],
+    "name:fin_x_preferred":[
         "Oracabessa"
     ],
     "name:fra_x_preferred":[
         "Oracabessa"
     ],
     "name:nld_x_preferred":[
+        "Oracabessa"
+    ],
+    "name:pol_x_preferred":[
+        "Oracabessa"
+    ],
+    "name:swe_x_preferred":[
         "Oracabessa"
     ],
     "name:zho_x_preferred":[
@@ -64,7 +79,7 @@
         }
     ],
     "wof:id":890429173,
-    "wof:lastmodified":1566724665,
+    "wof:lastmodified":1690937475,
     "wof:name":"Oracabessa",
     "wof:parent_id":85672605,
     "wof:placetype":"locality",

--- a/data/890/429/179/890429179.geojson
+++ b/data/890/429/179/890429179.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ceb_x_preferred":[
+        "Frome"
+    ],
+    "name:ell_x_preferred":[
+        "\u03a6\u03c1\u03bf\u03c5\u03bc"
+    ],
     "name:eng_x_preferred":[
         "Frome"
     ],
@@ -26,6 +32,9 @@
         "Frome"
     ],
     "name:nld_x_preferred":[
+        "Frome"
+    ],
+    "name:swe_x_preferred":[
         "Frome"
     ],
     "qs:name":"Frome",
@@ -61,7 +70,7 @@
         }
     ],
     "wof:id":890429179,
-    "wof:lastmodified":1566724665,
+    "wof:lastmodified":1690937476,
     "wof:name":"Frome",
     "wof:parent_id":85672583,
     "wof:placetype":"locality",

--- a/data/890/429/181/890429181.geojson
+++ b/data/890/429/181/890429181.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "Annotto Bay"
+    ],
+    "name:ceb_x_preferred":[
+        "Annotto Bay"
+    ],
     "name:deu_x_preferred":[
         "Annotto Bay"
     ],
@@ -32,6 +38,9 @@
         "Annotto Bay"
     ],
     "name:pol_x_preferred":[
+        "Annotto Bay"
+    ],
+    "name:swe_x_preferred":[
         "Annotto Bay"
     ],
     "name:und_x_variant":[
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":890429181,
-    "wof:lastmodified":1566724665,
+    "wof:lastmodified":1690937475,
     "wof:name":"Annotto Bay",
     "wof:parent_id":85672605,
     "wof:placetype":"locality",

--- a/data/890/433/235/890433235.geojson
+++ b/data/890/433/235/890433235.geojson
@@ -34,6 +34,9 @@
     "name:nld_x_preferred":[
         "Maggotty"
     ],
+    "name:pol_x_preferred":[
+        "Maggotty"
+    ],
     "name:swe_x_preferred":[
         "Maggotty"
     ],
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890433235,
-    "wof:lastmodified":1566724666,
+    "wof:lastmodified":1690937477,
     "wof:name":"Maggotty",
     "wof:parent_id":85672569,
     "wof:placetype":"locality",

--- a/data/890/434/771/890434771.geojson
+++ b/data/890/434/771/890434771.geojson
@@ -28,8 +28,17 @@
     "name:eng_x_preferred":[
         "Buff Bay"
     ],
+    "name:fra_x_preferred":[
+        "Buff Bay"
+    ],
     "name:nld_x_preferred":[
         "Buff Bay"
+    ],
+    "name:pol_x_preferred":[
+        "Buff Bay"
+    ],
+    "name:rus_x_preferred":[
+        "\u0411\u0430\u0444\u0444-\u0411\u044d\u0439"
     ],
     "name:swe_x_preferred":[
         "Buff Bay"
@@ -65,7 +74,7 @@
         }
     ],
     "wof:id":890434771,
-    "wof:lastmodified":1566724666,
+    "wof:lastmodified":1690937476,
     "wof:name":"Buff Bay",
     "wof:parent_id":85672591,
     "wof:placetype":"locality",

--- a/data/890/435/347/890435347.geojson
+++ b/data/890/435/347/890435347.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "Rocky Point"
+    ],
     "name:ceb_x_preferred":[
         "Rocky Point"
     ],
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890435347,
-    "wof:lastmodified":1566724666,
+    "wof:lastmodified":1690937477,
     "wof:name":"Rocky Point",
     "wof:parent_id":85672559,
     "wof:placetype":"locality",

--- a/data/890/435/481/890435481.geojson
+++ b/data/890/435/481/890435481.geojson
@@ -19,8 +19,20 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":7.0,
+    "name:ara_x_preferred":[
+        "\u0628\u0648\u0631\u062a \u0623\u0646\u0637\u0648\u0646\u064a\u0648"
+    ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u0631\u062a \u0627\u0646\u0637\u0648\u0646\u064a\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Port Antonio"
+    ],
     "name:ben_x_preferred":[
         "\u09aa\u09cb\u09b0\u09cd\u099f \u0985\u09cd\u09af\u09be\u09a8\u09cd\u09a4\u09cb\u09a8\u09bf\u09df\u09cb"
+    ],
+    "name:cat_x_preferred":[
+        "Port Antonio"
     ],
     "name:ceb_x_preferred":[
         "Port Antonio"
@@ -41,6 +53,9 @@
         "\u067e\u0648\u0631\u062a \u0622\u0646\u062a\u0648\u0646\u06cc\u0648"
     ],
     "name:fra_x_preferred":[
+        "Port Antonio"
+    ],
+    "name:gle_x_preferred":[
         "Port Antonio"
     ],
     "name:heb_x_preferred":[
@@ -70,6 +85,9 @@
     "name:kor_x_preferred":[
         "\ud3ec\ud2b8 \uc548\ud1a0\ub2c8\uc624"
     ],
+    "name:ltz_x_preferred":[
+        "Port Antonio"
+    ],
     "name:nld_x_preferred":[
         "Port Antonio"
     ],
@@ -96,6 +114,9 @@
     ],
     "name:tur_x_preferred":[
         "Port Antonio"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041f\u043e\u0440\u0442-\u0410\u043d\u0442\u043e\u043d\u0456\u043e"
     ],
     "name:und_x_variant":[
         "Saint Francois"
@@ -243,7 +264,7 @@
         }
     ],
     "wof:id":890435481,
-    "wof:lastmodified":1636495995,
+    "wof:lastmodified":1690937477,
     "wof:name":"Port Antonio",
     "wof:parent_id":85672591,
     "wof:placetype":"locality",

--- a/data/890/439/969/890439969.geojson
+++ b/data/890/439/969/890439969.geojson
@@ -25,11 +25,20 @@
     "name:ara_x_preferred":[
         "\u0633\u0628\u0627\u0646\u064a\u0634 \u062a\u0627\u0648\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0628\u0627\u0646\u064a\u0634 \u062a\u0627\u0648\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Spanish Town"
+    ],
     "name:bel_x_preferred":[
         "\u0421\u043f\u0430\u043d\u0456\u0448-\u0422\u0430\u045e\u043d"
     ],
     "name:ben_x_preferred":[
         "\u09b8\u09cd\u09aa\u09cd\u09af\u09be\u09a8\u09bf\u09b8 \u099f\u09be\u0989\u09a8"
+    ],
+    "name:bul_x_preferred":[
+        "\u0421\u043f\u0430\u043d\u0438\u0448 \u0422\u0430\u0443\u043d"
     ],
     "name:cat_x_preferred":[
         "Spanish Town"
@@ -61,10 +70,16 @@
     "name:eus_x_preferred":[
         "Spanish Town"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u0633\u067e\u0646\u06cc\u0634 \u062a\u0627\u0648\u0646"
+    ],
     "name:fin_x_preferred":[
         "Spanish Town"
     ],
     "name:fra_x_preferred":[
+        "Spanish Town"
+    ],
+    "name:gle_x_preferred":[
         "Spanish Town"
     ],
     "name:guj_x_preferred":[
@@ -78,6 +93,9 @@
     ],
     "name:hun_x_preferred":[
         "Spanish Town"
+    ],
+    "name:hye_x_preferred":[
+        "\u054d\u057a\u0565\u0576\u056b\u0577 \u0569\u0561\u0578\u0582\u0576"
     ],
     "name:ind_x_preferred":[
         "Spanish Town"
@@ -136,6 +154,9 @@
     "name:swe_x_preferred":[
         "Spanish Town"
     ],
+    "name:szl_x_preferred":[
+        "Spanish Town"
+    ],
     "name:tam_x_preferred":[
         "\u0bb8\u0bcd\u0baa\u0bbe\u0ba8\u0bbf\u0bb7\u0bcd \u0ba8\u0b95\u0bb0\u0bae\u0bcd"
     ],
@@ -157,7 +178,13 @@
     "name:urd_x_preferred":[
         "\u0633\u067e\u06cc\u0646\u0634 \u0679\u0627\u0624\u0646"
     ],
+    "name:vec_x_preferred":[
+        "Spanish Town"
+    ],
     "name:vie_x_preferred":[
+        "Spanish Town"
+    ],
+    "name:war_x_preferred":[
         "Spanish Town"
     ],
     "name:zho_x_preferred":[
@@ -297,7 +324,7 @@
         }
     ],
     "wof:id":890439969,
-    "wof:lastmodified":1636495995,
+    "wof:lastmodified":1690937473,
     "wof:name":"Spanish Town",
     "wof:parent_id":85672601,
     "wof:placetype":"locality",

--- a/data/890/444/671/890444671.geojson
+++ b/data/890/444/671/890444671.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_preferred":[
         "\u0645\u0648\u0646\u062a\u064a\u063a\u0648 \u0628\u0627\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0648\u0646\u062a\u064a\u062c\u0648 \u0628\u0627\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Montego Bay"
+    ],
     "name:aze_x_preferred":[
         "Monteqo-Bey"
     ],
@@ -36,6 +42,9 @@
     ],
     "name:bre_x_preferred":[
         "Montego Bay"
+    ],
+    "name:bul_x_preferred":[
+        "\u041c\u043e\u043d\u0442\u0435\u0433\u043e \u0411\u0435\u0439"
     ],
     "name:cat_x_preferred":[
         "Montego Bay"
@@ -55,6 +64,9 @@
     "name:ell_x_preferred":[
         "\u039c\u03bf\u03bd\u03c4\u03ad\u03b3\u03ba\u03bf \u039c\u03c0\u03ad\u03c5"
     ],
+    "name:ell_x_variant":[
+        "\u039c\u03bf\u03bd\u03c4\u03ad\u03b3\u03ba\u03bf \u039c\u03c0\u03ad\u03b9"
+    ],
     "name:eng_x_preferred":[
         "Montego Bay"
     ],
@@ -71,6 +83,9 @@
         "Montego Bay"
     ],
     "name:fra_x_preferred":[
+        "Montego Bay"
+    ],
+    "name:gle_x_preferred":[
         "Montego Bay"
     ],
     "name:glg_x_preferred":[
@@ -139,6 +154,9 @@
     "name:nob_x_preferred":[
         "Montego Bay"
     ],
+    "name:oss_x_preferred":[
+        "\u041c\u043e\u043d\u0442\u0435\u0433\u043e-\u0411\u0435\u0439"
+    ],
     "name:pol_x_preferred":[
         "Montego Bay"
     ],
@@ -184,7 +202,13 @@
     "name:urd_x_preferred":[
         "\u0645\u0648\u0646\u0679\u06cc\u06af\u0648 \u0628\u06d2"
     ],
+    "name:vec_x_preferred":[
+        "Montego Bay"
+    ],
     "name:vie_x_preferred":[
+        "Montego Bay"
+    ],
+    "name:war_x_preferred":[
         "Montego Bay"
     ],
     "name:zho_x_preferred":[
@@ -324,7 +348,7 @@
         }
     ],
     "wof:id":890444671,
-    "wof:lastmodified":1582319503,
+    "wof:lastmodified":1690937475,
     "wof:name":"Montego Bay",
     "wof:parent_id":85672573,
     "wof:placetype":"locality",

--- a/data/890/444/675/890444675.geojson
+++ b/data/890/444/675/890444675.geojson
@@ -19,10 +19,22 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:bul_x_preferred":[
+        "\u041a\u0435\u043b\u0438\u0446"
+    ],
+    "name:ceb_x_preferred":[
+        "Kellits"
+    ],
     "name:eng_x_preferred":[
         "Kellits"
     ],
+    "name:jpn_x_preferred":[
+        "\u30b1\u30ea\u30c3\u30c4"
+    ],
     "name:nld_x_preferred":[
+        "Kellits"
+    ],
+    "name:swe_x_preferred":[
         "Kellits"
     ],
     "name:und_x_variant":[
@@ -59,7 +71,7 @@
         }
     ],
     "wof:id":890444675,
-    "wof:lastmodified":1566724665,
+    "wof:lastmodified":1690937474,
     "wof:name":"Kellits",
     "wof:parent_id":85672559,
     "wof:placetype":"locality",

--- a/data/890/444/677/890444677.geojson
+++ b/data/890/444/677/890444677.geojson
@@ -22,8 +22,14 @@
     "name:ara_x_preferred":[
         "\u0647\u0627\u064a\u0632"
     ],
+    "name:ast_x_preferred":[
+        "Hayes"
+    ],
     "name:ben_x_preferred":[
         "\u09b9\u09c7\u099c"
+    ],
+    "name:ceb_x_preferred":[
+        "Hayes"
     ],
     "name:deu_x_preferred":[
         "Hayes"
@@ -49,10 +55,16 @@
     "name:kor_x_preferred":[
         "\ud5e4\uc774\uc988"
     ],
+    "name:lit_x_preferred":[
+        "Heisas"
+    ],
     "name:nld_x_preferred":[
         "Hayes"
     ],
     "name:pol_x_preferred":[
+        "Hayes"
+    ],
+    "name:swe_x_preferred":[
         "Hayes"
     ],
     "name:tur_x_preferred":[
@@ -104,7 +116,7 @@
         }
     ],
     "wof:id":890444677,
-    "wof:lastmodified":1636495995,
+    "wof:lastmodified":1690937475,
     "wof:name":"Hayes",
     "wof:parent_id":85672559,
     "wof:placetype":"locality",

--- a/data/890/444/679/890444679.geojson
+++ b/data/890/444/679/890444679.geojson
@@ -19,10 +19,19 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:bul_x_preferred":[
+        "\u0413\u0430\u0439\u043b\u0435"
+    ],
+    "name:ceb_x_preferred":[
+        "Gayle"
+    ],
     "name:eng_x_preferred":[
         "Gayle"
     ],
     "name:nld_x_preferred":[
+        "Gayle"
+    ],
+    "name:swe_x_preferred":[
         "Gayle"
     ],
     "name:und_x_variant":[
@@ -59,7 +68,7 @@
         }
     ],
     "wof:id":890444679,
-    "wof:lastmodified":1566724665,
+    "wof:lastmodified":1690937475,
     "wof:name":"Gayle",
     "wof:parent_id":85672605,
     "wof:placetype":"locality",

--- a/data/890/444/681/890444681.geojson
+++ b/data/890/444/681/890444681.geojson
@@ -31,6 +31,9 @@
     "name:nld_x_preferred":[
         "Bamboo"
     ],
+    "name:pol_x_preferred":[
+        "Bamboo"
+    ],
     "name:swe_x_preferred":[
         "Bamboo"
     ],
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890444681,
-    "wof:lastmodified":1566724665,
+    "wof:lastmodified":1690937474,
     "wof:name":"Bamboo",
     "wof:parent_id":85672599,
     "wof:placetype":"locality",

--- a/data/890/452/717/890452717.geojson
+++ b/data/890/452/717/890452717.geojson
@@ -19,11 +19,17 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "Bethel Town"
+    ],
     "name:ceb_x_preferred":[
         "Bethel Town"
     ],
     "name:deu_x_preferred":[
         "Bethel Town"
+    ],
+    "name:ell_x_preferred":[
+        "\u039c\u03c0\u03ad\u03b8\u03b5\u03bb \u03a4\u03ac\u03bf\u03c5\u03bd"
     ],
     "name:eng_x_preferred":[
         "Bethel Town"
@@ -68,7 +74,7 @@
         }
     ],
     "wof:id":890452717,
-    "wof:lastmodified":1566724665,
+    "wof:lastmodified":1690937473,
     "wof:name":"Bethel Town",
     "wof:parent_id":85672583,
     "wof:placetype":"locality",

--- a/data/890/454/113/890454113.geojson
+++ b/data/890/454/113/890454113.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":10.0,
+    "name:ast_x_preferred":[
+        "Ewarton"
+    ],
     "name:ceb_x_preferred":[
         "Ewarton"
     ],
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":890454113,
-    "wof:lastmodified":1566724665,
+    "wof:lastmodified":1690937474,
     "wof:name":"Ewarton",
     "wof:parent_id":85672601,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.