### PR TITLE
jm concordances, placetype local, and more

### DIFF
--- a/data/856/322/15/85632215.geojson
+++ b/data/856/322/15/85632215.geojson
@@ -1176,6 +1176,7 @@
         "hasc:id":"JM",
         "icao:code":"6Y",
         "ioc:id":"JAM",
+        "iso:code":"JM",
         "itu:id":"JMC",
         "loc:id":"n81008540",
         "m49:code":"388",
@@ -1190,6 +1191,7 @@
         "wk:page":"Jamaica",
         "wmo:id":"JM"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JM",
     "wof:country_alpha3":"JAM",
     "wof:geom_alt":[
@@ -1212,7 +1214,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639514,
+    "wof:lastmodified":1695881169,
     "wof:name":"Jamaica",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/725/59/85672559.geojson
+++ b/data/856/725/59/85672559.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.101603,
-    "geom:area_square_m":1194900687.061292,
+    "geom:area_square_m":1194900687.06095,
     "geom:bbox":"-77.484819,17.70548,-77.124524,18.222762",
     "geom:latitude":17.991397,
     "geom:longitude":-77.279237,
@@ -286,17 +286,19 @@
         "gn:id":3490952,
         "gp:id":2345912,
         "hasc:id":"JM.CL",
+        "iso:code":"JM-13",
         "iso:id":"JM-13",
         "qs_pg:id":221175,
         "unlc:id":"JM-13",
         "wd:id":"Q1095557",
         "wk:page":"Clarendon Parish, Jamaica"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a79ac9b958fb663d2158ca2eb837cb4b",
+    "wof:geomhash":"f72b1089069e00099241828e560c684e",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -311,7 +313,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690937455,
+    "wof:lastmodified":1695884835,
     "wof:name":"Clarendon",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/63/85672563.geojson
+++ b/data/856/725/63/85672563.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03851,
-    "geom:area_square_m":451883616.021474,
+    "geom:area_square_m":451883616.021322,
     "geom:bbox":"-78.344668,18.307772,-77.909728,18.462863",
     "geom:latitude":18.38536,
     "geom:longitude":-78.125659,
@@ -288,17 +288,19 @@
         "gn:id":3490145,
         "gp:id":2345913,
         "hasc:id":"JM.HA",
+        "iso:code":"JM-09",
         "iso:id":"JM-09",
         "qs_pg:id":221176,
         "unlc:id":"JM-09",
         "wd:id":"Q1131779",
         "wk:page":"Hanover Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e9cc00ab37bf48c87b29202df63c668e",
+    "wof:geomhash":"91b76584bfdd3813b61ef19998adbd6b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -313,7 +315,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690937458,
+    "wof:lastmodified":1695884836,
     "wof:name":"Hanover",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/67/85672567.geojson
+++ b/data/856/725/67/85672567.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071283,
-    "geom:area_square_m":838105782.981081,
+    "geom:area_square_m":838105782.981562,
     "geom:bbox":"-77.632002,17.841903,-77.354387,18.254153",
     "geom:latitude":18.03718,
     "geom:longitude":-77.505414,
@@ -276,17 +276,19 @@
         "gn:id":3489586,
         "gp:id":2345914,
         "hasc:id":"JM.MA",
+        "iso:code":"JM-12",
         "iso:id":"JM-12",
         "qs_pg:id":427267,
         "unlc:id":"JM-12",
         "wd:id":"Q920496",
         "wk:page":"Manchester Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"521c1f561ff94765eb0c515fb86da9fd",
+    "wof:geomhash":"90b478a7de75c14b5e460a9e76b291ef",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -301,7 +303,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690937456,
+    "wof:lastmodified":1695884835,
     "wof:name":"Manchester",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/69/85672569.geojson
+++ b/data/856/725/69/85672569.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102732,
-    "geom:area_square_m":1207714588.090441,
+    "geom:area_square_m":1207714588.090578,
     "geom:bbox":"-77.950819,17.854521,-77.566632,18.249906",
     "geom:latitude":18.060743,
     "geom:longitude":-77.743083,
@@ -285,17 +285,19 @@
         "gn:id":3488708,
         "gp:id":2345919,
         "hasc:id":"JM.SE",
+        "iso:code":"JM-11",
         "iso:id":"JM-11",
         "qs_pg:id":219569,
         "unlc:id":"JM-11",
         "wd:id":"Q1473646",
         "wk:page":"Saint Elizabeth Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9b5df93618b608962337b2162a2675c3",
+    "wof:geomhash":"902d7b1080d49f6547162ca357674a38",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -310,7 +312,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690937455,
+    "wof:lastmodified":1695884835,
     "wof:name":"Saint Elizabeth",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/73/85672573.geojson
+++ b/data/856/725/73/85672573.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05076,
-    "geom:area_square_m":595605826.958028,
+    "geom:area_square_m":595605826.958128,
     "geom:bbox":"-77.996968,18.214514,-77.735295,18.525489",
     "geom:latitude":18.39021,
     "geom:longitude":-77.846529,
@@ -303,17 +303,19 @@
         "gn:id":3488700,
         "gp:id":2345920,
         "hasc:id":"JM.SJ",
+        "iso:code":"JM-08",
         "iso:id":"JM-08",
         "qs_pg:id":219570,
         "unlc:id":"JM-08",
         "wd:id":"Q1421939",
         "wk:page":"Saint James Parish, Jamaica"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c6b895cd13482d2e5a0486f311f9b5aa",
+    "wof:geomhash":"f6d116b7c80792f3b56d0948b8abd8a4",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -328,7 +330,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690937456,
+    "wof:lastmodified":1695884835,
     "wof:name":"Saint James",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/79/85672579.geojson
+++ b/data/856/725/79/85672579.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.074635,
-    "geom:area_square_m":875872036.628088,
+    "geom:area_square_m":875872037.438403,
     "geom:bbox":"-77.771946,18.205258,-77.441612,18.5117",
     "geom:latitude":18.36488,
     "geom:longitude":-77.605739,
@@ -291,17 +291,19 @@
         "gn:id":3488222,
         "gp:id":2345923,
         "hasc:id":"JM.TR",
+        "iso:code":"JM-07",
         "iso:id":"JM-07",
         "qs_pg:id":894900,
         "unlc:id":"JM-07",
         "wd:id":"Q1123340",
         "wk:page":"Trelawny Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"df0bbde37cd28d35ccd86a346548d8cc",
+    "wof:geomhash":"da42699f056f4f5ee7f645a6bc0bf4be",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -316,7 +318,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690937458,
+    "wof:lastmodified":1695884836,
     "wof:name":"Trelawny",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/83/85672583.geojson
+++ b/data/856/725/83/85672583.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067482,
-    "geom:area_square_m":792449119.36259,
+    "geom:area_square_m":792449119.362179,
     "geom:bbox":"-78.368198,18.06126,-77.872883,18.358076",
     "geom:latitude":18.251691,
     "geom:longitude":-78.092276,
@@ -280,17 +280,19 @@
         "gn:id":3488081,
         "gp:id":2345924,
         "hasc:id":"JM.WE",
+        "iso:code":"JM-10",
         "iso:id":"JM-10",
         "qs_pg:id":894901,
         "unlc:id":"JM-10",
         "wd:id":"Q1440250",
         "wk:page":"Westmoreland Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fbf10b497be8dce3f8b49067b00c8fdc",
+    "wof:geomhash":"d6aaab14591c5b30e209118b69464b36",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -305,7 +307,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690937459,
+    "wof:lastmodified":1695884836,
     "wof:name":"Westmoreland",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/87/85672587.geojson
+++ b/data/856/725/87/85672587.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001898,
-    "geom:area_square_m":22326932.233152,
+    "geom:area_square_m":22326932.233131,
     "geom:bbox":"-76.846774,17.928238,-76.719651,17.986246",
     "geom:latitude":17.962849,
     "geom:longitude":-76.777263,
@@ -324,17 +324,19 @@
         "gn:id":3489853,
         "gp:id":2345925,
         "hasc:id":"JM.KI",
+        "iso:code":"JM-01",
         "iso:id":"JM-01",
         "qs_pg:id":894902,
         "unlc:id":"JM-01",
         "wd:id":"Q1473680",
         "wk:page":"Kingston Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"64611cb20eb56ce0c125e11c7fe1bca0",
+    "wof:geomhash":"08cc7e3e795dfb1465331c39e41b60e3",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -349,7 +351,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690937456,
+    "wof:lastmodified":1695884835,
     "wof:name":"Kingston",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/91/85672591.geojson
+++ b/data/856/725/91/85672591.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070148,
-    "geom:area_square_m":824374593.558188,
+    "geom:area_square_m":824374593.558125,
     "geom:bbox":"-76.753109,17.988346,-76.256928,18.267077",
     "geom:latitude":18.120509,
     "geom:longitude":-76.514989,
@@ -267,17 +267,19 @@
         "gn:id":3488997,
         "gp:id":2345915,
         "hasc:id":"JM.PO",
+        "iso:code":"JM-04",
         "iso:id":"JM-04",
         "qs_pg:id":219567,
         "unlc:id":"JM-04",
         "wd:id":"Q125148",
         "wk:page":"Portland Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6ac351cf09cd09f9276429158c018bcc",
+    "wof:geomhash":"16bb1aa5562221fb53e5dc8dc84462b6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -292,7 +294,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690937457,
+    "wof:lastmodified":1695884835,
     "wof:name":"Portland",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/725/99/85672599.geojson
+++ b/data/856/725/99/85672599.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.105282,
-    "geom:area_square_m":1235810507.348759,
+    "geom:area_square_m":1235810504.416704,
     "geom:bbox":"-77.486802,18.185078,-76.996063,18.4819",
     "geom:latitude":18.32499,
     "geom:longitude":-77.259002,
@@ -296,17 +296,19 @@
         "gn:id":3488715,
         "gp:id":2345917,
         "hasc:id":"JM.SN",
+        "iso:code":"JM-06",
         "iso:id":"JM-06",
         "qs_pg:id":1168671,
         "unlc:id":"JM-06",
         "wd:id":"Q1326284",
         "wk:page":"Saint Ann Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ae5be037b6081d3ebcdbc790c923306e",
+    "wof:geomhash":"96bec69d3cc7f044b6496ec999a5baf6",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -321,7 +323,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690937457,
+    "wof:lastmodified":1695884836,
     "wof:name":"Saint Ann",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/726/01/85672601.geojson
+++ b/data/856/726/01/85672601.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.101406,
-    "geom:area_square_m":1192167692.1445,
+    "geom:area_square_m":1192167692.144787,
     "geom:bbox":"-77.211266,17.839677,-76.838312,18.263517",
     "geom:latitude":18.053641,
     "geom:longitude":-77.017944,
@@ -294,17 +294,19 @@
         "gn:id":3488711,
         "gp:id":2345918,
         "hasc:id":"JM.SC",
+        "iso:code":"JM-14",
         "iso:id":"JM-14",
         "qs_pg:id":423784,
         "unlc:id":"JM-14",
         "wd:id":"Q1473663",
         "wk:page":"Saint Catherine Parish"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"510205f42883420e6233e89e0a6903c5",
+    "wof:geomhash":"a06430d57835c41eb307415779b9ac3c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -319,7 +321,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690937460,
+    "wof:lastmodified":1695884836,
     "wof:name":"Saint Catherine",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/726/05/85672605.geojson
+++ b/data/856/726/05/85672605.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052018,
-    "geom:area_square_m":610738242.840511,
+    "geom:area_square_m":610738242.647544,
     "geom:bbox":"-77.072364,18.136519,-76.700028,18.424139",
     "geom:latitude":18.285405,
     "geom:longitude":-76.888383,
@@ -286,17 +286,19 @@
         "gn:id":3488693,
         "gp:id":2345921,
         "hasc:id":"JM.SM",
+        "iso:code":"JM-05",
         "iso:id":"JM-05",
         "qs_pg:id":235602,
         "unlc:id":"JM-05",
         "wd:id":"Q633565",
         "wk:page":"Saint Mary Parish, Jamaica"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"13e4b25d2a453b7842177bf0bc4c016b",
+    "wof:geomhash":"25791f319d1ec7ae8e56f2ca7291fd4c",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -311,7 +313,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690937460,
+    "wof:lastmodified":1695884836,
     "wof:name":"Saint Mary",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/726/09/85672609.geojson
+++ b/data/856/726/09/85672609.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037039,
-    "geom:area_square_m":435445581.385109,
+    "geom:area_square_m":435445581.385042,
     "geom:bbox":"-76.887905,17.937815,-76.617122,18.179596",
     "geom:latitude":18.052291,
     "geom:longitude":-76.760774,
@@ -309,17 +309,19 @@
         "gn:id":3488716,
         "gp:id":2345916,
         "hasc:id":"JM.SD",
+        "iso:code":"JM-02",
         "iso:id":"JM-02",
         "qs_pg:id":219568,
         "unlc:id":"JM-02",
         "wd:id":"Q2212935",
         "wk:page":"Saint Andrew Parish, Jamaica"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"01935785ba280ebcf3ac3b02bbafbc4e",
+    "wof:geomhash":"d10bd57666a1040baa414f1a9721bf67",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -334,7 +336,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690937460,
+    "wof:lastmodified":1695884837,
     "wof:name":"Saint Andrew",
     "wof:parent_id":85632215,
     "wof:placetype":"region",

--- a/data/856/726/15/85672615.geojson
+++ b/data/856/726/15/85672615.geojson
@@ -7,7 +7,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063273,
-    "geom:area_square_m":744294385.390898,
+    "geom:area_square_m":744294385.391142,
     "geom:bbox":"-76.666759,17.849738,-76.182652,18.092017",
     "geom:latitude":17.950731,
     "geom:longitude":-76.452706,
@@ -298,17 +298,19 @@
         "gn:id":3488688,
         "gp:id":2345922,
         "hasc:id":"JM.ST",
+        "iso:code":"JM-03",
         "iso:id":"JM-03",
         "qs_pg:id":235603,
         "unlc:id":"JM-03",
         "wd:id":"Q1422332",
         "wk:page":"Saint Thomas Parish, Jamaica"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JM",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2546a34f7479ed0886b3f5c10196c14c",
+    "wof:geomhash":"b6bf097dc5c7fa93ccf23847b80fa966",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -323,7 +325,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690937461,
+    "wof:lastmodified":1695884837,
     "wof:name":"Saint Thomas",
     "wof:parent_id":85632215,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.